### PR TITLE
Card #103: Fixed error in Android login screen

### DIFF
--- a/src/screens/LoginScreen/LoginScreen.tsx
+++ b/src/screens/LoginScreen/LoginScreen.tsx
@@ -33,8 +33,9 @@ export default () => {
 				return;
 			}
 			case 401: Alert.alert('Incorrect email or password'); return;
+			case 404: Alert.alert('Server not found - please try again'); return;
 			case 500: Alert.alert('Network error - please try again'); return;
-			default: Alert.alert(statusCode);
+			default: Alert.alert(`Server replied with ${statusCode} status code`);
 		}
 	};
 


### PR DESCRIPTION
The crash was caused by a UnexpectedNativeTypeException that is thrown when calling Alert.alert() is called with a number type. The login action returned a 404 status code when the server was down, which resulted in the call to Alert.alert() without converting it to a string.

This was fixed by adding a case for 404, and including a full message, as a string, as the default error message.