### PR TITLE
Reference local rails API during development

### DIFF
--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -16,7 +16,7 @@ const getEnv = () => {
 	return ({
 		...variantSpecificProperties,
 		USER_IDENTITY: variant,
-		API_BASE_URL: 'https://banana-rails.herokuapp.com',
+		API_BASE_URL: __DEV__ ? 'http://localhost:3000' : 'https://banana-rails.herokuapp.com',
 	});
 };
 


### PR DESCRIPTION
API requests now point to the local Rails server during development and point to the Heroku app during production.