### PR TITLE
Fix PR typechecking error, change zipcode to string

### DIFF
--- a/src/screens/RegistrationScreen/ClientRegistrationScreen.tsx
+++ b/src/screens/RegistrationScreen/ClientRegistrationScreen.tsx
@@ -76,7 +76,7 @@ export default () => {
 	const [ street, setStreet ] = useState('');
 	const [ city, setCity ] = useState('');
 	const [ state, setState ] = useState('WA');
-	const [ zip, setZip ] = useState();
+	const [ zip, setZip ] = useState('');
 	const [ transportationMethod, setTransportationMethod ] = useState();
 	const [ gender, setGender ] = useState();
 	const [ ethnicity, setEthnicity ] = useState();
@@ -91,7 +91,7 @@ export default () => {
 		if (password.length < 8) { Alert.alert('Please enter a password at least 8 characters long.'); return; }
 		if (!street || street.split(' ').length < 3) { Alert.alert('Please enter your street number and name.'); return; }
 		if (!city) { Alert.alert('Please enter your city.'); return; }
-		if (zip.toString().length !== 5) { Alert.alert('Please enter your 5-digit zip code.'); return; }
+		if (!(/^\d{5}$/.test(zip))) { Alert.alert('Please enter a valid 5-digit zip code.'); return; }
 		if (!transportationMethod) { Alert.alert('Please select your preferred method of transportation.'); return; }
 		if (!termsOfService) { Alert.alert('Please read and accept the terms of service to complete your registration.'); return; }
 

--- a/src/screens/RegistrationScreen/DonorRegistrationScreen.tsx
+++ b/src/screens/RegistrationScreen/DonorRegistrationScreen.tsx
@@ -31,14 +31,14 @@ export default () => {
 
 	const [ city, setCity ] = useState('');
 	const [ email, setEmail ] = useState('');
-	const [ image, setImage ] = useState();
+	const [ image, setImage ] = useState({} as ImagePicker.ImagePickerResult);
 	const [ license, setLicense ] = useState('');
 	const [ organizationName, setOrganizationName ] = useState('');
 	const [ password, setPassword ] = useState('');
 	const [ street, setStreet ] = useState('');
 	const [ state, _setState ] = useState('WA');
 	const [ termsOfService, setTermsOfService ] = useState(false);
-	const [ zip, setZip ] = useState();
+	const [ zip, setZip ] = useState('');
 
 	const toggleTermsOfService = () => setTermsOfService(!termsOfService);
 
@@ -50,7 +50,7 @@ export default () => {
 		if (!image) { Alert.alert('Please add an image of your business license to continue.'); return; }
 		if (!street || street.split(' ').length < 3) { Alert.alert('Please enter your street number and name.'); return; }
 		if (!city) { Alert.alert('Please enter your city.'); return; }
-		if (zip.toString().length !== 5) { Alert.alert('Please enter your 5-digit zip code.'); return; }
+		if (!(/^\d{5}$/.test(zip))) { Alert.alert('Please enter a valid 5-digit zip code.'); return; }
 		if (!termsOfService) { Alert.alert('Please read and accept the terms of service to complete your registration.'); return; }
 
 		const statusCode = await register({
@@ -116,7 +116,7 @@ export default () => {
 					<View style={styles.row}>
 						<View style={{ flex: 4 }}>
 							<TextInput
-								value={image?.uri}
+								value={!image.cancelled ? image.uri : ''}
 								style={styles.input}
 								autoCapitalize="none"
 							/>

--- a/src/state/actions/register.ts
+++ b/src/state/actions/register.ts
@@ -8,7 +8,8 @@ interface DonorRegisterProps {
 	street: string;
 	city: string;
 	state: string;
-	zip: number;
+	zip: string;
+	licenseVerificationImage: any;
 }
 
 interface ClientRegisterProps {
@@ -17,7 +18,7 @@ interface ClientRegisterProps {
 	street: string;
 	city: string;
 	state: string;
-	zip: number;
+	zip: string;
 	transportationMethod: string;
 	ethnicity: string;
 	gender: string;

--- a/src/state/index.types.ts
+++ b/src/state/index.types.ts
@@ -15,7 +15,7 @@ export interface SharedProps {
 	address_street: string;
 	address_city: string;
 	address_state: string;
-	address_zip: number;
+	address_zip: string;
 	account_status: string;
 	coords: {
 		latitude?: number;

--- a/src/util/register.ts
+++ b/src/util/register.ts
@@ -9,7 +9,7 @@ interface RegisterProps {
 	street: string;
 	city: string;
 	state: string;
-	zip: number;
+	zip: string;
 	termsOfService: boolean;
 }
 


### PR DESCRIPTION
Fix type errors that fail PR build checks.

Reasons for type change: Zipcode is a nominal variable (numeric operations are meaningless), so they should be treated as strings and verified as integers. This change enables a valid initialization value for the zipcode field, which fixes the typechecking errors.