### PR TITLE
[TR_137] Button and Text Button components - READY FOR REVIEW 

### DIFF
--- a/src/elements/Button/Button.styles.ts
+++ b/src/elements/Button/Button.styles.ts
@@ -1,5 +1,4 @@
 import { StyleSheet } from 'react-native';
-import * as colors from '@util/colors';
 
 export default StyleSheet.create({
 	container: {
@@ -21,24 +20,5 @@ export default StyleSheet.create({
 	compact: {
 		width: 'fit-content',
 		borderRadius: 100,
-	},
-	default: {
-		backgroundColor: colors.GRAY,
-		color: colors.NAVY_BLUE,
-	},
-	primary: {
-		backgroundColor: colors.NAVY_BLUE,
-		color: colors.WHITE,
-	},
-	accent: {
-		backgroundColor: colors.RED,
-		color: colors.WHITE,
-	},
-	disabled: {
-		backgroundColor: colors.LIGHT_GRAY_DISABLED,
-	},
-	active: {
-		backgroundColor: colors.BANANA_YELLOW,
-		color: colors.NAVY_BLUE,
 	},
 });

--- a/src/elements/Button/Button.styles.ts
+++ b/src/elements/Button/Button.styles.ts
@@ -1,0 +1,44 @@
+import { StyleSheet } from 'react-native';
+import * as colors from '@util/colors';
+
+export default StyleSheet.create({
+	container: {
+		height: 45,
+		paddingHorizontal: 10,
+		paddingVertical: 16,
+		minWidth: 'fit-content',
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	text: {
+		fontFamily: 'open-sans-bold',
+		fontSize: 16,
+		textTransform: 'uppercase',
+		textAlign: 'center',
+		color: 'inherit',
+		whiteSpace: 'nowrap',
+	},
+	compact: {
+		width: 'fit-content',
+		borderRadius: 100,
+	},
+	default: {
+		backgroundColor: colors.GRAY,
+		color: colors.NAVY_BLUE,
+	},
+	primary: {
+		backgroundColor: colors.NAVY_BLUE,
+		color: colors.WHITE,
+	},
+	accent: {
+		backgroundColor: colors.RED,
+		color: colors.WHITE,
+	},
+	disabled: {
+		backgroundColor: colors.LIGHT_GRAY_DISABLED,
+	},
+	active: {
+		backgroundColor: colors.BANANA_YELLOW,
+		color: colors.NAVY_BLUE,
+	},
+});

--- a/src/elements/Button/Button.styles.ts
+++ b/src/elements/Button/Button.styles.ts
@@ -8,6 +8,8 @@ export default StyleSheet.create({
 		minWidth: 'fit-content',
 		justifyContent: 'center',
 		alignItems: 'center',
+		borderWidth: 0,
+		borderStyle: 'solid',
 	},
 	text: {
 		fontFamily: 'open-sans-bold',

--- a/src/elements/Button/Button.styles.ts
+++ b/src/elements/Button/Button.styles.ts
@@ -19,8 +19,4 @@ export default StyleSheet.create({
 		color: 'inherit',
 		whiteSpace: 'nowrap',
 	},
-	compact: {
-		width: 'fit-content',
-		borderRadius: 100,
-	},
 });

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -3,54 +3,51 @@
 
 import React, { useState } from 'react';
 import {
-	TouchableHighlight, StyleProp, ViewStyle, TextStyle, TouchableHighlightProps,
+	TouchableHighlight,
+	TouchableHighlightProps,
+	StyleProp,
+	TextStyle,
+	ViewStyle,
 } from 'react-native';
-import { ColorPalette, COLOR_SCHEMES, ColorScheme } from '@util/colorSchemes';
+import { COLOR_SCHEMES, ColorScheme } from '@util/colorSchemes';
 import { useColorScheme } from 'react-native-appearance';
+import { DARK_GRAY_TRANSPARENT } from '@util/colors';
 import styles from './Button.styles';
 
 export type ButtonProps = TouchableHighlightProps & {
 	children: React.ReactNode; // Elements to be wrapped by the button.
-	activeStyle?: StyleProp<ViewStyle>; // Styling for the button during an 'active' pseudo-state.
-	palette?: Omit<ColorPalette, 'disabled'>; // Determines the color styling of the button.
+	pressedStyle?: StyleProp<TextStyle>; // Styling for the button during an 'active' pseudo-state.
+	disabledStyle?: StyleProp<TextStyle>; // Styling for the button if it's disabled.
 	outlined?: boolean; // Whether the button is styled with an outline and transparent body.
-	compact?: boolean; // Whether the button should be without padding.
 };
 
 export default ({
 	children,
-	style = {},
-	activeStyle = {}, // TODO: test
-	palette = 'default',
+	style,
+	pressedStyle,
+	disabledStyle,
 	outlined = false,
-	compact = false, // TODO: test
 	disabled = false,
 	activeOpacity = 0.8,
 	onShowUnderlay = () => { },
 	onHideUnderlay = () => { },
 	...props
 }: ButtonProps) => {
-	const getPalette = () => {
-		const scheme: ColorScheme = COLOR_SCHEMES[useColorScheme()];
-		return disabled ? scheme.disabled : scheme[palette as ColorPalette];
-	};
-
-	const colorPalette = getPalette();
+	const scheme: ColorScheme = COLOR_SCHEMES[useColorScheme()];
+	const defaultStyle = scheme.default;
+	const defaultDisabledStyle = scheme.disabled;
 
 	// Underlay color is showed when the button is active.
-	const UNDERLAY_COLOR = (activeStyle as ViewStyle)?.backgroundColor || colorPalette.color;
-	const BORDER_COLOR = (style as TextStyle)?.color || colorPalette.color;
+	const UNDERLAY_COLOR = (pressedStyle as TextStyle)?.backgroundColor
+		|| DARK_GRAY_TRANSPARENT;
 
-	// Default styling for the 'tertiary' palette.
-	const defaultTertiaryStyle = {
+	// Outline styling
+	const borderColorSource = disabled ? disabledStyle || defaultDisabledStyle : style || defaultStyle;
+	const BORDER_COLOR = (borderColorSource as TextStyle).color;
+	const outlineBorder: ViewStyle = {
 		borderColor: BORDER_COLOR,
-		borderWidth: outlined ? 2 : undefined,
-	};
-
-	// Default active style is the background color and text color swapped.
-	const defaultActiveStyle = {
-		backgroundColor: colorPalette.color,
-		color: outlined ? 'white' : colorPalette.backgroundColor,
+		borderWidth: 2,
+		borderStyle: 'solid',
 	};
 
 	// Whether or not the button is pressed/ active.
@@ -60,11 +57,11 @@ export default ({
 		<TouchableHighlight
 			style={[
 				styles.container,
-				defaultTertiaryStyle,
-				compact && styles.compact,
+				defaultStyle,
+				outlined && outlineBorder,
 				style,
-				colorPalette,
-				pressed && !disabled && (activeStyle || defaultActiveStyle),
+				pressed && pressedStyle,
+				disabled && (disabledStyle || defaultDisabledStyle),
 			]}
 			underlayColor={UNDERLAY_COLOR}
 			activeOpacity={activeOpacity}

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-	TouchableHighlight, FlexStyle, StyleProp, ViewStyle,
+	TouchableHighlight, FlexStyle, StyleProp, ViewStyle, TextStyle,
 } from 'react-native';
 import { ColorPalette, COLOR_SCHEMES, ColorScheme } from '@util/colorSchemes';
 import { useColorScheme } from 'react-native-appearance';
@@ -13,7 +13,8 @@ export type ButtonProps = {
 	activeStyle?: StyleProp<ViewStyle>; // Styling for the button during an 'active' pseudo-state.
 	disabled?: boolean; // Whether the button can be interacted with.
 	palette?: Omit<ColorPalette, 'disabled'>; // Determines the color styling of the button.
-	compact?: boolean; // Whether the button should be
+	compact?: boolean; // Whether the button should be without padding.
+	outlined?: boolean; // Whether the button is styled with an outline and transparent body.
 };
 
 export default ({
@@ -24,12 +25,17 @@ export default ({
 	disabled = false,
 	palette = 'default',
 	compact = false, // TODO: test
+	outlined = false,
 }: ButtonProps) => {
 	const scheme: ColorScheme = COLOR_SCHEMES[useColorScheme()];
 	const colorPalette = disabled ? scheme.disabled : scheme[palette as ColorPalette];
 
 	// The color showed when the button is active.
-	const UNDERLAY_COLOR = (activeStyle as ViewStyle)?.backgroundColor || scheme.secondary.backgroundColor;
+	const UNDERLAY_COLOR = (activeStyle as ViewStyle)?.backgroundColor || colorPalette.color;
+
+	const BORDER_COLOR = (style as TextStyle)?.color || colorPalette.color;
+	const defaultTertiaryStyle = { borderColor: BORDER_COLOR, borderWidth: outlined ? 2 : undefined };
+	const defaultActiveStyle = { backgroundColor: colorPalette.color, color: outlined ? 'white' : colorPalette.backgroundColor };
 
 	const [ pressed, setPressed ] = useState(false); // Whether or not the button is pressed/ active.
 
@@ -38,10 +44,11 @@ export default ({
 			onPress={() => !disabled && onPress()}
 			style={[
 				styles.container,
+				defaultTertiaryStyle,
 				compact && styles.compact,
 				style,
 				colorPalette,
-				pressed && !disabled && (activeStyle || scheme.secondary),
+				pressed && !disabled && (activeStyle || defaultActiveStyle),
 			]}
 			underlayColor={UNDERLAY_COLOR}
 			activeOpacity={0.8}

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -1,47 +1,63 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React, { useState } from 'react';
 import {
-	TouchableHighlight, FlexStyle, StyleProp, ViewStyle, TextStyle,
+	TouchableHighlight, StyleProp, ViewStyle, TextStyle, TouchableHighlightProps,
 } from 'react-native';
 import { ColorPalette, COLOR_SCHEMES, ColorScheme } from '@util/colorSchemes';
 import { useColorScheme } from 'react-native-appearance';
 import styles from './Button.styles';
 
-export type ButtonProps = {
-	onPress: Function; // Callback function called with the button is pressed.
-	children?: JSX.Element; // Elements to be wrapped by the button.
-	style?: StyleProp<FlexStyle>; // Dimension styling for the button root.
+export type ButtonProps = TouchableHighlightProps & {
+	children: React.ReactNode; // Elements to be wrapped by the button.
 	activeStyle?: StyleProp<ViewStyle>; // Styling for the button during an 'active' pseudo-state.
-	disabled?: boolean; // Whether the button can be interacted with.
 	palette?: Omit<ColorPalette, 'disabled'>; // Determines the color styling of the button.
-	compact?: boolean; // Whether the button should be without padding.
 	outlined?: boolean; // Whether the button is styled with an outline and transparent body.
+	compact?: boolean; // Whether the button should be without padding.
 };
 
 export default ({
-	onPress,
 	children,
-	activeStyle, // TODO: test
 	style = {},
-	disabled = false,
+	activeStyle = {}, // TODO: test
 	palette = 'default',
-	compact = false, // TODO: test
 	outlined = false,
+	compact = false, // TODO: test
+	disabled = false,
+	activeOpacity = 0.8,
+	onShowUnderlay = () => { },
+	onHideUnderlay = () => { },
+	...props
 }: ButtonProps) => {
-	const scheme: ColorScheme = COLOR_SCHEMES[useColorScheme()];
-	const colorPalette = disabled ? scheme.disabled : scheme[palette as ColorPalette];
+	const getPalette = () => {
+		const scheme: ColorScheme = COLOR_SCHEMES[useColorScheme()];
+		return disabled ? scheme.disabled : scheme[palette as ColorPalette];
+	};
 
-	// The color showed when the button is active.
+	const colorPalette = getPalette();
+
+	// Underlay color is showed when the button is active.
 	const UNDERLAY_COLOR = (activeStyle as ViewStyle)?.backgroundColor || colorPalette.color;
-
 	const BORDER_COLOR = (style as TextStyle)?.color || colorPalette.color;
-	const defaultTertiaryStyle = { borderColor: BORDER_COLOR, borderWidth: outlined ? 2 : undefined };
-	const defaultActiveStyle = { backgroundColor: colorPalette.color, color: outlined ? 'white' : colorPalette.backgroundColor };
 
-	const [ pressed, setPressed ] = useState(false); // Whether or not the button is pressed/ active.
+	// Default styling for the 'tertiary' palette.
+	const defaultTertiaryStyle = {
+		borderColor: BORDER_COLOR,
+		borderWidth: outlined ? 2 : undefined,
+	};
+
+	// Default active style is the background color and text color swapped.
+	const defaultActiveStyle = {
+		backgroundColor: colorPalette.color,
+		color: outlined ? 'white' : colorPalette.backgroundColor,
+	};
+
+	// Whether or not the button is pressed/ active.
+	const [ pressed, setPressed ] = useState(false);
 
 	return (
 		<TouchableHighlight
-			onPress={() => !disabled && onPress()}
 			style={[
 				styles.container,
 				defaultTertiaryStyle,
@@ -51,10 +67,11 @@ export default ({
 				pressed && !disabled && (activeStyle || defaultActiveStyle),
 			]}
 			underlayColor={UNDERLAY_COLOR}
-			activeOpacity={0.8}
+			activeOpacity={activeOpacity}
 			disabled={disabled}
-			onShowUnderlay={() => setPressed(true)}
-			onHideUnderlay={() => setPressed(false)}
+			onShowUnderlay={() => { setPressed(true); onShowUnderlay(); }}
+			onHideUnderlay={() => { setPressed(false); onHideUnderlay(); }}
+			{...props}
 		>
 			{children}
 		</TouchableHighlight>

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import {
+	TouchableHighlight, FlexStyle, StyleProp, ViewStyle,
+} from 'react-native';
+import styles from './Button.styles';
+
+/**
+ * ButtonType
+ *
+ * default = Gray background, blue text.
+ * primary = Blue background, white text.
+ * accent = Red background, white text.
+ */
+type ButtonType = 'default' | 'primary' | 'accent';
+
+export type ButtonProps = {
+	onPress: Function; // Callback function called with the button is pressed.
+	style?: StyleProp<FlexStyle>; // Dimension styling for the button root.
+	disabled?: boolean; // Whether the button can be interacted with.
+	type?: ButtonType; // Determines the color styling of the button.
+	compact?: boolean; // Whether the button should be
+	activeStyle?: StyleProp<ViewStyle>; // Styling for the button during an 'active' pseudo-state.
+	children?: JSX.Element; // Elements to be wrapped by the button.
+};
+
+export default ({
+	onPress,
+	style = {},
+	disabled = false,
+	type = 'default',
+	compact = false,
+	activeStyle,
+	children,
+}: ButtonProps) => {
+	// The color showed when the button is active
+	const UNDERLAY_COLOR = (activeStyle as ViewStyle)?.backgroundColor || styles.active.backgroundColor;
+
+	const [ pressed, setPressed ] = useState(false); // Whether or not the button is pressed/ active.
+
+	return (
+		<TouchableHighlight
+			onPress={() => !disabled && onPress()}
+			style={[
+				styles.container,
+				compact && styles.compact,
+				style,
+				styles[type],
+				pressed && (activeStyle || styles.active),
+				disabled && styles.disabled,
+			]}
+			underlayColor={UNDERLAY_COLOR}
+			activeOpacity={0.8}
+			disabled={disabled}
+			onShowUnderlay={() => setPressed(true)}
+			onHideUnderlay={() => setPressed(false)}
+		>
+			{children}
+		</TouchableHighlight>
+	);
+};

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -2,38 +2,34 @@ import React, { useState } from 'react';
 import {
 	TouchableHighlight, FlexStyle, StyleProp, ViewStyle,
 } from 'react-native';
+import { ColorPalette, COLOR_SCHEMES, ColorScheme } from '@util/colorSchemes';
+import { useColorScheme } from 'react-native-appearance';
 import styles from './Button.styles';
-
-/**
- * ButtonType
- *
- * default = Gray background, blue text.
- * primary = Blue background, white text.
- * accent = Red background, white text.
- */
-type ButtonType = 'default' | 'primary' | 'accent';
 
 export type ButtonProps = {
 	onPress: Function; // Callback function called with the button is pressed.
-	style?: StyleProp<FlexStyle>; // Dimension styling for the button root.
-	disabled?: boolean; // Whether the button can be interacted with.
-	type?: ButtonType; // Determines the color styling of the button.
-	compact?: boolean; // Whether the button should be
-	activeStyle?: StyleProp<ViewStyle>; // Styling for the button during an 'active' pseudo-state.
 	children?: JSX.Element; // Elements to be wrapped by the button.
+	style?: StyleProp<FlexStyle>; // Dimension styling for the button root.
+	activeStyle?: StyleProp<ViewStyle>; // Styling for the button during an 'active' pseudo-state.
+	disabled?: boolean; // Whether the button can be interacted with.
+	palette?: Omit<ColorPalette, 'disabled'>; // Determines the color styling of the button.
+	compact?: boolean; // Whether the button should be
 };
 
 export default ({
 	onPress,
+	children,
+	activeStyle, // TODO: test
 	style = {},
 	disabled = false,
-	type = 'default',
-	compact = false,
-	activeStyle,
-	children,
+	palette = 'default',
+	compact = false, // TODO: test
 }: ButtonProps) => {
-	// The color showed when the button is active
-	const UNDERLAY_COLOR = (activeStyle as ViewStyle)?.backgroundColor || styles.active.backgroundColor;
+	const scheme: ColorScheme = COLOR_SCHEMES[useColorScheme()];
+	const colorPalette = disabled ? scheme.disabled : scheme[palette as ColorPalette];
+
+	// The color showed when the button is active.
+	const UNDERLAY_COLOR = (activeStyle as ViewStyle)?.backgroundColor || scheme.secondary.backgroundColor;
 
 	const [ pressed, setPressed ] = useState(false); // Whether or not the button is pressed/ active.
 
@@ -44,9 +40,8 @@ export default ({
 				styles.container,
 				compact && styles.compact,
 				style,
-				styles[type],
-				pressed && (activeStyle || styles.active),
-				disabled && styles.disabled,
+				colorPalette,
+				pressed && !disabled && (activeStyle || scheme.secondary),
 			]}
 			underlayColor={UNDERLAY_COLOR}
 			activeOpacity={0.8}

--- a/src/elements/Button/TextButton/TextButton.tsx
+++ b/src/elements/Button/TextButton/TextButton.tsx
@@ -9,20 +9,17 @@ type TextButtonProps = { text: string; textStyle?: StyleProp<TextStyle> } & Butt
 
 export default ({
 	text,
-	onPress,
-	style = {},
 	textStyle = {},
-	disabled = false,
 	palette = 'default',
 	compact = false,
+	...props
 }: TextButtonProps) => (
 	<Button
-		onPress={onPress}
-		style={style}
-		disabled={disabled}
-		palette={palette}
 		compact={compact}
 		outlined={palette === 'tertiary'}
+		palette={palette}
+		// eslint-disable-next-line react/jsx-props-no-spreading
+		{...props}
 	>
 		<Text style={[ styles.text, textStyle ]}>{text}</Text>
 	</Button>

--- a/src/elements/Button/TextButton/TextButton.tsx
+++ b/src/elements/Button/TextButton/TextButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {
+	Text,
+} from 'react-native';
+import styles from '../Button.styles';
+import Button, { ButtonProps } from '../Button';
+
+type TextButtonProps = { text: string } & ButtonProps;
+
+export default ({
+	text,
+	onPress,
+	style = {},
+	disabled = false,
+	type = 'default',
+	compact = false,
+}: TextButtonProps) => (
+	<Button
+		onPress={onPress}
+		style={style}
+		disabled={disabled}
+		type={type}
+		compact={compact}
+	>
+		<Text style={[ styles.text ]}>{text}</Text>
+	</Button>
+);

--- a/src/elements/Button/TextButton/TextButton.tsx
+++ b/src/elements/Button/TextButton/TextButton.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import {
-	Text,
+	Text, TextStyle, StyleProp,
 } from 'react-native';
 import styles from '../Button.styles';
 import Button, { ButtonProps } from '../Button';
 
-type TextButtonProps = { text: string } & ButtonProps;
+type TextButtonProps = { text: string; textStyle?: StyleProp<TextStyle> } & ButtonProps;
 
 export default ({
 	text,
 	onPress,
 	style = {},
+	textStyle = {},
 	disabled = false,
 	palette = 'default',
 	compact = false,
@@ -21,7 +22,8 @@ export default ({
 		disabled={disabled}
 		palette={palette}
 		compact={compact}
+		outlined={palette === 'tertiary'}
 	>
-		<Text style={[ styles.text ]}>{text}</Text>
+		<Text style={[ styles.text, textStyle ]}>{text}</Text>
 	</Button>
 );

--- a/src/elements/Button/TextButton/TextButton.tsx
+++ b/src/elements/Button/TextButton/TextButton.tsx
@@ -12,14 +12,14 @@ export default ({
 	onPress,
 	style = {},
 	disabled = false,
-	type = 'default',
+	palette = 'default',
 	compact = false,
 }: TextButtonProps) => (
 	<Button
 		onPress={onPress}
 		style={style}
 		disabled={disabled}
-		type={type}
+		palette={palette}
 		compact={compact}
 	>
 		<Text style={[ styles.text ]}>{text}</Text>

--- a/src/elements/Button/TextButton/TextButton.tsx
+++ b/src/elements/Button/TextButton/TextButton.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React from 'react';
 import {
 	Text, TextStyle, StyleProp,
@@ -5,20 +7,24 @@ import {
 import styles from '../Button.styles';
 import Button, { ButtonProps } from '../Button';
 
-type TextButtonProps = { text: string; textStyle?: StyleProp<TextStyle> } & ButtonProps;
+type TextButtonProps = { text: string; textStyle?: StyleProp<TextStyle> } & Omit<ButtonProps, 'children'>;
 
 export default ({
 	text,
-	textStyle = {},
-	palette = 'default',
-	compact = false,
+	textStyle, // 'backgroundColor' and 'color' will override pressed and disabled styling
+	style,
+	pressedStyle,
+	disabledStyle,
+	outlined = false,
+	disabled = false,
 	...props
 }: TextButtonProps) => (
 	<Button
-		compact={compact}
-		outlined={palette === 'tertiary'}
-		palette={palette}
-		// eslint-disable-next-line react/jsx-props-no-spreading
+		style={style}
+		pressedStyle={pressedStyle}
+		disabledStyle={disabledStyle}
+		outlined={outlined}
+		disabled={disabled}
 		{...props}
 	>
 		<Text style={[ styles.text, textStyle ]}>{text}</Text>

--- a/src/elements/Button/TextButton/index.ts
+++ b/src/elements/Button/TextButton/index.ts
@@ -1,0 +1,3 @@
+import TextButton from './TextButton';
+
+export { TextButton };

--- a/src/elements/Button/index.ts
+++ b/src/elements/Button/index.ts
@@ -1,0 +1,3 @@
+import Button from './Button';
+
+export { Button };

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -2,6 +2,8 @@ export { FormTextInput } from './FormTextInput';
 export { Header } from './Header';
 export { Icon } from './Icon';
 export { InputLabel } from './FormTextInput/InputLabel';
+export { Button } from './Button';
+export { TextButton } from './Button/TextButton';
 export { LinkButton } from './LinkButton';
 export { SpacerInline } from './SpacerInline';
 export { Title } from './Title';


### PR DESCRIPTION
- Add a button wrapper component that can wrap any content
- Add a text button component that utilizes the button wrapper
for only text content

The Button simplifies the ability to manage styling button 'pseudo-classes' in native.
The TextButton utilizes the button component, but restricts content to text.

Both components are 'prop transparent'; they both expose and pass on all TouchableHighlight props, which allows them to be more flexible when using.

![Buttons Interaction GIF](https://user-images.githubusercontent.com/9058130/77807823-3fe1b680-7046-11ea-8229-848840419e89.gif)
GIF note: Every other button has optional outlining. These don't follow the Style Guide.

---
### Style Guide
![Button3+4](https://user-images.githubusercontent.com/9058130/77808320-145fcb80-7048-11ea-933c-f01a2a91e144.png)

##### _Examples of more button types that can be made with the Button component._
![Selection1+2](https://user-images.githubusercontent.com/9058130/77808316-132e9e80-7048-11ea-81c5-abc726d16ead.png)
![Button7](https://user-images.githubusercontent.com/9058130/77808319-13c73500-7048-11ea-9514-c2aedeeeabbf.png)


