### PR TITLE
[TR_96] Modal Component - READY FOR REVIEW

### DIFF
--- a/src/elements/Modal/Modal.styles.ts
+++ b/src/elements/Modal/Modal.styles.ts
@@ -1,0 +1,60 @@
+import { StyleSheet } from 'react-native';
+import * as colors from '@util/colors';
+
+export default StyleSheet.create({
+	wrapper: {
+		width: '100%',
+		height: '100%',
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	underlay: {
+		width: '100%',
+		height: '100%',
+		position: 'absolute',
+		backgroundColor: colors.WHITE_TRANSPARENT,
+	},
+	container: {
+		width: 'calc(100% - 15px)',
+		height: 'fit-content',
+		position: 'absolute',
+		alignItems: 'center',
+		overflow: 'hidden',
+		borderRadius: 10,
+		shadowColor: 'rgba(0, 0, 0, 0.25)',
+		shadowOffset: {
+			width: 0,
+			height: 4,
+		},
+		shadowRadius: 4,
+	},
+	header: {
+		width: '100%',
+		height: 80,
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: colors.BANANA_YELLOW,
+	},
+	title: {
+		width: '95%',
+		textAlign: 'center',
+		color: colors.NAVY_BLUE,
+		fontFamily: 'open-sans-bold',
+		fontSize: 20,
+		whiteSpace: 'normal',
+	},
+	body: {
+		width: '100%',
+		height: 'fit-content',
+		paddingVertical: 20,
+		paddingHorizontal: 18,
+		alignItems: 'center',
+		backgroundColor: colors.WHITE,
+		maxHeight: 350,
+		// TODO: find max-height relative to screen height?
+	},
+	bodyContent: {
+		overflow: 'scroll',
+		height: '100%',
+	},
+});

--- a/src/elements/Modal/Modal.styles.ts
+++ b/src/elements/Modal/Modal.styles.ts
@@ -41,7 +41,7 @@ export default StyleSheet.create({
 	title: {
 		width: '95%',
 		textAlign: 'center',
-		color: colors.NAVY_BLUE,
+		color: 'inherit',
 		fontFamily: 'open-sans-bold',
 		fontSize: 20,
 		whiteSpace: 'normal',

--- a/src/elements/Modal/Modal.styles.ts
+++ b/src/elements/Modal/Modal.styles.ts
@@ -36,7 +36,6 @@ export default StyleSheet.create({
 		height: 80,
 		alignItems: 'center',
 		justifyContent: 'center',
-		backgroundColor: colors.BANANA_YELLOW,
 	},
 	title: {
 		width: '95%',
@@ -49,15 +48,15 @@ export default StyleSheet.create({
 	body: {
 		width: '100%',
 		height: 'fit-content',
-		paddingVertical: 20,
-		paddingHorizontal: 18,
 		alignItems: 'center',
 		backgroundColor: colors.WHITE,
-		maxHeight: 350,
-		// TODO: find max-height relative to screen height?
+		maxHeight: '56.25vh',
 	},
 	bodyContent: {
 		overflow: 'scroll',
 		height: '100%',
+		width: '100%',
+		paddingVertical: 20,
+		paddingHorizontal: 18,
 	},
 });

--- a/src/elements/Modal/Modal.styles.ts
+++ b/src/elements/Modal/Modal.styles.ts
@@ -48,7 +48,6 @@ export default StyleSheet.create({
 	body: {
 		width: '100%',
 		height: 'fit-content',
-		alignItems: 'center',
 		backgroundColor: colors.WHITE,
 		maxHeight: '56.25vh',
 	},

--- a/src/elements/Modal/Modal.styles.ts
+++ b/src/elements/Modal/Modal.styles.ts
@@ -1,6 +1,9 @@
 import { StyleSheet } from 'react-native';
 import * as colors from '@util/colors';
 
+// Position of the modal relative to its container.
+export const DEFAULT_TOP_OFFSET = 90;
+
 export default StyleSheet.create({
 	wrapper: {
 		width: '100%',

--- a/src/elements/Modal/Modal.styles.ts
+++ b/src/elements/Modal/Modal.styles.ts
@@ -20,6 +20,7 @@ export default StyleSheet.create({
 	container: {
 		width: 'calc(100% - 15px)',
 		height: 'fit-content',
+		minHeight: 362,
 		position: 'absolute',
 		alignItems: 'center',
 		overflow: 'hidden',
@@ -47,7 +48,7 @@ export default StyleSheet.create({
 	},
 	body: {
 		width: '100%',
-		height: 'fit-content',
+		height: '100%',
 		backgroundColor: colors.WHITE,
 		maxHeight: '56.25vh',
 	},
@@ -57,5 +58,8 @@ export default StyleSheet.create({
 		width: '100%',
 		paddingVertical: 20,
 		paddingHorizontal: 18,
+		color: colors.NAVY_BLUE,
+		textAlign: 'center',
+		justifyContent: 'space-around',
 	},
 });

--- a/src/elements/Modal/Modal.tsx
+++ b/src/elements/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
-import styles from './Modal.styles';
+import styles, { DEFAULT_TOP_OFFSET } from './Modal.styles';
 
 interface ModalProps {
 	title: string; // Title text show in the header.
@@ -11,7 +11,7 @@ interface ModalProps {
 }
 
 export default ({
-	title, open, top = 90, onClose, children,
+	top = DEFAULT_TOP_OFFSET,
 }: ModalProps) => {
 	const handleUnderlayPress = () => {
 		if (open) {

--- a/src/elements/Modal/Modal.tsx
+++ b/src/elements/Modal/Modal.tsx
@@ -6,7 +6,7 @@ import styles, { DEFAULT_TOP_OFFSET } from './Modal.styles';
 
 
 interface ModalProps {
-	title: string; // Title text show in the header.
+	title: string; // Title text shown in the header.
 	open: boolean; // Whether the modal is open.
 	top?: number; // Top offset for the modal relative to its parent.
 	palette?: ColorPalette; // The color theme for the modal.
@@ -15,6 +15,8 @@ interface ModalProps {
 }
 
 export default ({
+	title,
+	open,
 	top = DEFAULT_TOP_OFFSET,
 	palette = 'default',
 	onClose,
@@ -31,7 +33,6 @@ export default ({
 	return (
 		<View style={[ styles.wrapper, !open && { width: 0, height: 0 } ]}>
 			<TouchableOpacity style={styles.underlay} onPress={handleUnderlayPress} />
-
 			<View style={[ styles.container, { top } ]}>
 				<View style={[ colorScheme[palette], styles.header ]}>
 					<Text
@@ -40,7 +41,6 @@ export default ({
 						{title.toUpperCase()}
 					</Text>
 				</View>
-
 				<View style={styles.body}>
 					<View style={styles.bodyContent}>
 						{children}

--- a/src/elements/Modal/Modal.tsx
+++ b/src/elements/Modal/Modal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import styles from './Modal.styles';
+
+interface ModalProps {
+	title: string; // Title text show in the header.
+	open: boolean; // Whether the modal is open.
+	top?: number; // Top offset for the modal. Default: 90px.
+	onClose: Function; // Callback for when the modal 'should' close.
+	children: JSX.Element; // Content element of the modal.
+}
+
+export default ({
+	title, open, top = 90, onClose, children,
+}: ModalProps) => {
+	const handleUnderlayPress = () => {
+		if (open) {
+			onClose();
+		}
+	};
+
+	return (
+		<View style={[ styles.wrapper, !open && { width: 0, height: 0 } ]}>
+			<TouchableOpacity style={styles.underlay} onPress={handleUnderlayPress} />
+
+			<View style={[ styles.container, { top } ]}>
+				<View style={styles.header}>
+					<Text
+						style={styles.title}
+					>
+						{title.toUpperCase()}
+					</Text>
+				</View>
+
+				<View style={styles.body}>
+					<View style={styles.bodyContent}>
+						{children}
+					</View>
+				</View>
+			</View>
+		</View>
+	);
+};

--- a/src/elements/Modal/Modal.tsx
+++ b/src/elements/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { ColorPalette, COLOR_SCHEMES } from '@util/colorSchemes';
 import { useColorScheme } from 'react-native-appearance';
+import { ScrollView } from 'react-native-gesture-handler';
 import styles, { DEFAULT_TOP_OFFSET } from './Modal.styles';
 
 
@@ -42,9 +43,9 @@ export default ({
 					</Text>
 				</View>
 				<View style={styles.body}>
-					<View style={styles.bodyContent}>
+					<ScrollView contentContainerStyle={styles.bodyContent}>
 						{children}
-					</View>
+					</ScrollView>
 				</View>
 			</View>
 		</View>

--- a/src/elements/Modal/Modal.tsx
+++ b/src/elements/Modal/Modal.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import {
+	View, Text, TouchableOpacity, StyleProp, ViewStyle,
+} from 'react-native';
 import { ColorPalette, COLOR_SCHEMES } from '@util/colorSchemes';
 import { useColorScheme } from 'react-native-appearance';
 import { ScrollView } from 'react-native-gesture-handler';
@@ -7,32 +9,47 @@ import styles, { DEFAULT_TOP_OFFSET } from './Modal.styles';
 
 
 interface ModalProps {
-	title: string; // Title text shown in the header.
-	open: boolean; // Whether the modal is open.
-	top?: number; // Top offset for the modal relative to its parent.
-	palette?: ColorPalette; // The color theme for the modal.
-	onClose: Function; // Callback for when the modal 'should' close.
-	children: JSX.Element; // Content element of the modal.
+	/** Title text shown in the header. */
+	title: string; //
+
+	/** Whether the modal is open. */
+	open: boolean;
+
+	/** Styling of the modal root. */
+	style?: StyleProp<ViewStyle>;
+
+	/** Top offset for the modal relative to its parent. */
+	top?: number; //
+
+	/** The color theme for the modal. */
+	palette?: ColorPalette; //
+
+	/** Callback for when the user taps outside of the modal container. */
+	onDismiss: Function; //
+
+	/** Body content of the modal. */
+	children: JSX.Element | Array<JSX.Element>;
 }
 
 export default ({
 	title,
 	open,
+	style = {},
 	top = DEFAULT_TOP_OFFSET,
 	palette = 'default',
-	onClose,
+	onDismiss,
 	children,
 }: ModalProps) => {
 	const colorScheme = COLOR_SCHEMES[useColorScheme()];
 
 	const handleUnderlayPress = () => {
 		if (open) {
-			onClose();
+			onDismiss();
 		}
 	};
 
 	return (
-		<View style={[ styles.wrapper, !open && { width: 0, height: 0 } ]}>
+		<View style={[ style, styles.wrapper, !open && { width: 0, height: 0 } ]}>
 			<TouchableOpacity style={styles.underlay} onPress={handleUnderlayPress} />
 			<View style={[ styles.container, { top } ]}>
 				<View style={[ colorScheme[palette], styles.header ]}>

--- a/src/elements/Modal/Modal.tsx
+++ b/src/elements/Modal/Modal.tsx
@@ -1,18 +1,27 @@
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
+import { ColorPalette, COLOR_SCHEMES } from '@util/colorSchemes';
+import { useColorScheme } from 'react-native-appearance';
 import styles, { DEFAULT_TOP_OFFSET } from './Modal.styles';
+
 
 interface ModalProps {
 	title: string; // Title text show in the header.
 	open: boolean; // Whether the modal is open.
-	top?: number; // Top offset for the modal. Default: 90px.
+	top?: number; // Top offset for the modal relative to its parent.
+	palette?: ColorPalette; // The color theme for the modal.
 	onClose: Function; // Callback for when the modal 'should' close.
 	children: JSX.Element; // Content element of the modal.
 }
 
 export default ({
 	top = DEFAULT_TOP_OFFSET,
+	palette = 'default',
+	onClose,
+	children,
 }: ModalProps) => {
+	const colorScheme = COLOR_SCHEMES[useColorScheme()];
+
 	const handleUnderlayPress = () => {
 		if (open) {
 			onClose();
@@ -24,7 +33,7 @@ export default ({
 			<TouchableOpacity style={styles.underlay} onPress={handleUnderlayPress} />
 
 			<View style={[ styles.container, { top } ]}>
-				<View style={styles.header}>
+				<View style={[ colorScheme[palette], styles.header ]}>
 					<Text
 						style={styles.title}
 					>

--- a/src/elements/Modal/index.ts
+++ b/src/elements/Modal/index.ts
@@ -1,0 +1,3 @@
+import Modal from './Modal';
+
+export { Modal };

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -8,3 +8,4 @@ export { LinkButton } from './LinkButton';
 export { SpacerInline } from './SpacerInline';
 export { Title } from './Title';
 export { Paragraph } from './Paragraph';
+export { Modal } from './Modal';


### PR DESCRIPTION
After reviewing the uses of the the modal within the figma, the only consistencies across all of them were the title/header and styling. In response, the modal accepts children elements that will render within the body of the modal.

Styling of the modal was lightly stress-tested to ensure styling stayed consistent if the content was too large.

The modal accepts a callback that is called when the user presses upon the background underlay.

Currently, the modal shrinks down to zero width and height when it's not 'open'. Any alternative solutions that are better practice? Just set display to 'none'?