### PR TITLE
[TR_97] Alert Modal

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -48,7 +48,7 @@ export default function App() {
 			<Provider>
 				<View style={styles.container}>
 					<Route ref={navRef => NavigationService.setTopLevelNavigator(navRef)} />
-					<TheAlertModal message="Uh oh! An error occurred." />
+					<TheAlertModal />
 				</View>
 			</Provider>
 		</AppearanceProvider>

--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { AppearanceProvider } from 'react-native-appearance';
 import Constants from 'expo-constants';
 import * as Font from 'expo-font';
 import NavigationService from '@util/NavigationService';
+import { TheAlertModal } from '@elements';
 import Route from './src/routes/Route';
 import styles from './App.styles';
 
@@ -47,6 +48,7 @@ export default function App() {
 			<Provider>
 				<View style={styles.container}>
 					<Route ref={navRef => NavigationService.setTopLevelNavigator(navRef)} />
+					<TheAlertModal message="Uh oh! An error occurred." />
 				</View>
 			</Provider>
 		</AppearanceProvider>

--- a/src/elements/TheAlertModal/TheAlertModal.styles.ts
+++ b/src/elements/TheAlertModal/TheAlertModal.styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+	container: {
+		position: 'absolute',
+	},
+});

--- a/src/elements/TheAlertModal/TheAlertModal.styles.ts
+++ b/src/elements/TheAlertModal/TheAlertModal.styles.ts
@@ -4,4 +4,13 @@ export default StyleSheet.create({
 	container: {
 		position: 'absolute',
 	},
+	body: {
+		flexGrow: 1,
+		alignItems: 'center',
+	},
+	textContainer: {
+		padding: 15,
+		flexGrow: 1,
+		justifyContent: 'center',
+	},
 });

--- a/src/elements/TheAlertModal/TheAlertModal.tsx
+++ b/src/elements/TheAlertModal/TheAlertModal.tsx
@@ -47,10 +47,14 @@ export default () => {
 
 				<TextButton
 					text="OK"
-					style={[
-						colorScheme.primary,
-					]}
-					pressedStyle={colorScheme.secondary}
+					style={{
+						width: 104,
+					}}
+					buttonStyle={{
+						default: scheme.primary,
+						pressed: scheme.secondary,
+						disabled: scheme.disabled,
+					}}
 					onPress={handleCloseButtonPress}
 				/>
 			</View>

--- a/src/elements/TheAlertModal/TheAlertModal.tsx
+++ b/src/elements/TheAlertModal/TheAlertModal.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+	View, Text, Button,
+} from 'react-native';
+import useGlobal from '@state';
+import { Modal } from '@elements';
+import { Alert } from '@state/index.types';
+
+import styles from './TheAlertModal.styles';
+
+// TODO: add styling to modal body, can it be applied to the Modal component, and have it cascade to Alert's children?
+// TODO: replace Button element with custom TextButton element
+
+export default () => {
+	const [ globalState, globalActions ] = useGlobal() as any;
+	const { alert }: {alert: Alert} = globalState;
+	const { clearAlert } = globalActions;
+
+	const handleCloseButtonPress = () => {
+		clearAlert();
+	};
+
+	const handleDismiss = () => {
+		if (alert.dismissable) {
+			clearAlert();
+		}
+	};
+
+	return (
+		<Modal
+			style={styles.container}
+			title={alert?.title || 'Alert'}
+			palette="accent"
+			open={alert !== undefined}
+			onDismiss={handleDismiss}
+		>
+			<View>
+				<Text>{alert?.message || 'Uh oh, an unknown error occurred!'}</Text>
+
+				<Button title="OK" onPress={handleCloseButtonPress} />
+			</View>
+		</Modal>
+	);
+};

--- a/src/elements/TheAlertModal/TheAlertModal.tsx
+++ b/src/elements/TheAlertModal/TheAlertModal.tsx
@@ -9,8 +9,7 @@ import {
 	Modal,
 } from '@elements';
 import { Alert } from '@state/index.types';
-import { COLOR_SCHEMES } from '@util/colorSchemes';
-import { useTheme } from 'react-navigation';
+import { useScheme } from '@util/colorSchemes';
 import typography from '@util/typography';
 import styles from './TheAlertModal.styles';
 
@@ -19,7 +18,7 @@ export default () => {
 	const { alert }: { alert: Alert } = globalState;
 	const { clearAlert } = globalActions;
 
-	const colorScheme = COLOR_SCHEMES[useTheme()];
+	const scheme = useScheme();
 
 	const handleCloseButtonPress = () => {
 		clearAlert();

--- a/src/elements/TheAlertModal/TheAlertModal.tsx
+++ b/src/elements/TheAlertModal/TheAlertModal.tsx
@@ -1,20 +1,25 @@
 import React from 'react';
 import {
-	View, Text, Button,
+	Text,
+	View,
 } from 'react-native';
 import useGlobal from '@state';
-import { Modal } from '@elements';
+import {
+	TextButton,
+	Modal,
+} from '@elements';
 import { Alert } from '@state/index.types';
-
+import { COLOR_SCHEMES } from '@util/colorSchemes';
+import { useTheme } from 'react-navigation';
+import typography from '@util/typography';
 import styles from './TheAlertModal.styles';
-
-// TODO: add styling to modal body, can it be applied to the Modal component, and have it cascade to Alert's children?
-// TODO: replace Button element with custom TextButton element
 
 export default () => {
 	const [ globalState, globalActions ] = useGlobal() as any;
-	const { alert }: {alert: Alert} = globalState;
+	const { alert }: { alert: Alert } = globalState;
 	const { clearAlert } = globalActions;
+
+	const colorScheme = COLOR_SCHEMES[useTheme()];
 
 	const handleCloseButtonPress = () => {
 		clearAlert();
@@ -34,10 +39,21 @@ export default () => {
 			open={alert !== undefined}
 			onDismiss={handleDismiss}
 		>
-			<View>
-				<Text>{alert?.message || 'Uh oh, an unknown error occurred!'}</Text>
+			<View style={styles.body}>
+				<View style={styles.textContainer}>
+					<Text style={typography.body1}>
+						{alert?.message || 'Uh oh, an unknown error occurred!'}
+					</Text>
+				</View>
 
-				<Button title="OK" onPress={handleCloseButtonPress} />
+				<TextButton
+					text="OK"
+					style={[
+						colorScheme.primary,
+					]}
+					pressedStyle={colorScheme.secondary}
+					onPress={handleCloseButtonPress}
+				/>
 			</View>
 		</Modal>
 	);

--- a/src/elements/TheAlertModal/index.ts
+++ b/src/elements/TheAlertModal/index.ts
@@ -1,0 +1,3 @@
+import TheAlertModal from './TheAlertModal';
+
+export { TheAlertModal };

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -9,3 +9,4 @@ export { SpacerInline } from './SpacerInline';
 export { Title } from './Title';
 export { Paragraph } from './Paragraph';
 export { Modal } from './Modal';
+export { TheAlertModal } from './TheAlertModal';

--- a/src/state/actions/alert.ts
+++ b/src/state/actions/alert.ts
@@ -1,0 +1,9 @@
+import { Alert } from '../index.types';
+
+export const updateAlert = (store, alert: Alert) => {
+	store.setState({ alert });
+};
+
+export const clearAlert = (store => {
+	store.setState({ alert: undefined });
+});

--- a/src/state/actions/index.ts
+++ b/src/state/actions/index.ts
@@ -17,4 +17,4 @@ export { logIn, logOut } from './auth';
 export { postDonation } from './postDonation';
 export { register } from './register';
 export { scan } from './scan';
-
+export { updateAlert, clearAlert } from './alert';

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -15,6 +15,7 @@ export const initialState: InitialState = {
 	userIdentity: USER_IDENTITY,
 	apiBaseUrl: API_BASE_URL,
 	loginUrl: LOGIN_URL,
+	alert: undefined,
 	donationsOrClaims: [],
 	jwt: undefined,
 	user: undefined,

--- a/src/state/index.types.ts
+++ b/src/state/index.types.ts
@@ -64,7 +64,7 @@ export interface Alert {
 
 	/**
 	 * Whether the alert can be casually dismissed by the user
-	 * (e.g. tapping the content behind a modal).
+	 * (i.e. tapping the content behind a modal).
 	 */
 	dismissable?: boolean;
 }

--- a/src/state/index.types.ts
+++ b/src/state/index.types.ts
@@ -48,10 +48,32 @@ export interface Donation {
 	pickup_location: string;
 }
 
+/**
+ * An alert to be displayed to the user.
+ */
+export interface Alert {
+	/**
+	 * Title of the alert.
+	 */
+	title: string;
+
+	/**
+	 * Message to the user.
+	 */
+	message: string;
+
+	/**
+	 * Whether the alert can be casually dismissed by the user
+	 * (e.g. tapping the content behind a modal).
+	 */
+	dismissable?: boolean;
+}
+
 export interface InitialState {
 	userIdentity: 'donor' | 'client';
 	apiBaseUrl: string;
 	loginUrl: string;
+	alert?: Alert;
 	jwt?: string;
 	user?: DonorState | ClientState | SharedProps;
 	donationsOrClaims?: Donation[] | Claim[];


### PR DESCRIPTION
Adds an app-wide alert modal that, when revealed, spans the entire screen size and covers anything rendered within the `<Route ...` element in `App.tsx`.

Adds an alert message global variable that, when manipulated, reveals an alert modal.
Includes the option to allow the user to dismiss (tap behind the modal popup) rather than tap the close button.

Usage
---
The alert action accepts an `Alert` object.
```tsx
/**
 * An alert to be displayed to the user.
 */
export interface Alert {
	/**
	 * Title of the alert.
	 */
	title: string;

	/**
	 * Message to the user.
	 */
	message: string;

	/**
	 * Whether the alert can be casually dismissed by the user
	 * (i.e. tapping the content behind a modal).
	 */
	dismissable?: boolean;
}
```
Calling the function reveals the alert modal immediately.
```tsx
import useGlobal from "@state";

const [ state, { updateAlert } ] = useGlobal() as any;

updateAlert(
   { 
      title: 'Test Title', 
      message: 'Test Message', 
      dismissable: false,
   }
);
```

---
> ![Alert Modal Interaction Preview](https://user-images.githubusercontent.com/9058130/79374659-545df400-7f0c-11ea-9ecb-01bde1471084.gif)
_Example of dismissable and acknowledged interactions._

<img alt="Alert Modal Screenshot" src="https://user-images.githubusercontent.com/9058130/79374898-a0109d80-7f0c-11ea-865c-744663b9ff4e.png" width="50%" />