### PR TITLE
[TR_148] Typography

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,7 @@ export default function App() {
 
 	const loadFonts = async () => {
 		await Font.loadAsync({
+			// Expo doesn't currently (v36.0.0) support fontWeight or fontStyle
 			'open-sans-bold': require('./assets/fonts/OpenSans-Bold.ttf'),
 			'open-sans-regular': require('./assets/fonts/OpenSans-Regular.ttf'),
 			'open-sans-light': require('./assets/fonts/OpenSans-Light.ttf'),

--- a/src/util/colors.ts
+++ b/src/util/colors.ts
@@ -1,3 +1,4 @@
+export const LIGHT_BLUE = '#768FC0';
 export const NAVY_BLUE = '#083A9B';
 export const FADED_NAVY_BLUE = '#083A9BB3';
 export const LIGHT_YELLOW = '#FFF6C7';

--- a/src/util/typography.ts
+++ b/src/util/typography.ts
@@ -4,20 +4,21 @@
  * @packageDocumentation
  */
 
+import { TextStyle } from 'react-native';
 import { NAVY_BLUE, LIGHT_BLUE } from '@util/colors';
 
-const heading = {
+const heading: TextStyle = {
 	fontFamily: 'open-sans-bold',
 	color: NAVY_BLUE,
 	textTransform: 'uppercase',
 };
 
-const body = {
+const body: TextStyle = {
 	fontFamily: 'open-sans-regular',
 	color: NAVY_BLUE,
 };
 
-export default {
+const typography: Record<string, TextStyle> = {
 	h1: {
 		...heading,
 		fontSize: 40,
@@ -69,3 +70,5 @@ export default {
 		textTransform: 'uppercase',
 	},
 };
+
+export default typography;

--- a/src/util/typography.ts
+++ b/src/util/typography.ts
@@ -4,62 +4,68 @@
  * @packageDocumentation
  */
 
-import * as colors from '@util/colors';
+import { NAVY_BLUE, LIGHT_BLUE } from '@util/colors';
+
+const heading = {
+	fontFamily: 'open-sans-bold',
+	color: NAVY_BLUE,
+	textTransform: 'uppercase',
+};
+
+const body = {
+	fontFamily: 'open-sans-regular',
+	color: NAVY_BLUE,
+};
 
 export default {
 	h1: {
-		fontFamily: 'open-sans-bold',
+		...heading,
 		fontSize: 40,
-		color: colors.NAVY_BLUE,
 	},
 	h2: {
-		fontFamily: 'open-sans-bold',
+		...heading,
 		fontSize: 25,
-		color: colors.NAVY_BLUE,
 	},
 	h3: {
-		fontFamily: 'open-sans-bold',
+		...heading,
 		fontSize: 20,
-		color: colors.NAVY_BLUE,
 	},
 	h4: {
-		fontFamily: 'open-sans-bold',
+		...heading,
 		fontSize: 16,
-		color: colors.NAVY_BLUE,
 	},
 	h5: {
-		fontFamily: 'open-sans-bold',
+		...heading,
 		fontSize: 12,
-		color: colors.NAVY_BLUE,
 	},
 	body1: {
-		fontFamily: 'open-sans-regular',
+		...body,
 		fontSize: 16,
-		color: colors.NAVY_BLUE,
 	},
 	body2: {
-		fontFamily: 'open-sans-regular',
+		...body,
 		fontSize: 16,
-		color: colors.LIGHT_BLUE,
+		color: LIGHT_BLUE,
 	},
 	body3: {
-		fontFamily: 'open-sans-regular',
+		...body,
 		fontSize: 14,
-		color: colors.NAVY_BLUE,
+		textTransform: 'uppercase',
 	},
 	body4: {
-		fontFamily: 'open-sans-regular',
+		...body,
+		fontFamily: 'open-sans-light',
 		fontSize: 14,
-		color: colors.NAVY_BLUE,
 	},
 	body5: {
-		fontFamily: 'open-sans-regular',
+		...body,
 		fontSize: 12,
-		color: colors.NAVY_BLUE,
+		textTransform: 'uppercase',
 	},
 	body6: {
-		fontFamily: 'open-sans-regular',
+		...body,
+		fontFamily: 'open-sans-bold',
 		fontSize: 12,
-		color: colors.NAVY_BLUE,
+		textTransform: 'uppercase',
 	},
 };

--- a/src/util/typography.ts
+++ b/src/util/typography.ts
@@ -1,0 +1,59 @@
+import * as colors from '@util/colors';
+
+export default {
+	h1: {
+		fontFamily: 'open-sans-bold',
+		fontSize: 40,
+		color: colors.NAVY_BLUE,
+	},
+	h2: {
+		fontFamily: 'open-sans-bold',
+		fontSize: 25,
+		color: colors.NAVY_BLUE,
+	},
+	h3: {
+		fontFamily: 'open-sans-bold',
+		fontSize: 20,
+		color: colors.NAVY_BLUE,
+	},
+	h4: {
+		fontFamily: 'open-sans-bold',
+		fontSize: 16,
+		color: colors.NAVY_BLUE,
+	},
+	h5: {
+		fontFamily: 'open-sans-bold',
+		fontSize: 12,
+		color: colors.NAVY_BLUE,
+	},
+	body1: {
+		fontFamily: 'open-sans-regular',
+		fontSize: 16,
+		color: colors.NAVY_BLUE,
+	},
+	body2: {
+		fontFamily: 'open-sans-regular',
+		fontSize: 16,
+		color: colors.LIGHT_BLUE,
+	},
+	body3: {
+		fontFamily: 'open-sans-regular',
+		fontSize: 14,
+		color: colors.NAVY_BLUE,
+	},
+	body4: {
+		fontFamily: 'open-sans-regular',
+		fontSize: 14,
+		color: colors.NAVY_BLUE,
+	},
+	body5: {
+		fontFamily: 'open-sans-regular',
+		fontSize: 12,
+		color: colors.NAVY_BLUE,
+	},
+	body6: {
+		fontFamily: 'open-sans-regular',
+		fontSize: 12,
+		color: colors.NAVY_BLUE,
+	},
+};

--- a/src/util/typography.ts
+++ b/src/util/typography.ts
@@ -1,3 +1,9 @@
+/**
+ * Standardized typography styling.
+ *
+ * @packageDocumentation
+ */
+
 import * as colors from '@util/colors';
 
 export default {


### PR DESCRIPTION
---

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch.

---

### [Trello Card](https://trello.com/c/SOJBqE0n)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Style Update according to [Figma Style Guide - Typography](https://www.figma.com/file/Kzv8b6CHHq5Y5aCuBWAGLU/THE-BANANA-APP-BGP?node-id=3889%3A11269).


#### What is the current behavior? (You can also link to an open issue here)
No typography styles to be used by the devs!


#### What is the new behavior? (if this is a feature change)
Single file reference for typography styles. :smiley: 


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


#### Other information
- Added new LIGHT_BLUE color.
- Looked into using fontWeight/ fontStyle properties.
  - Added a comment to explain that Expo doesn't support this.

#### Questions
- Should this PR include updating style declarations in components, where these style properties are being redundantly used?

---

#### Images (before/ after screenshots, interaction GIFs, ...)
![Typography_preview](https://user-images.githubusercontent.com/9058130/77809363-77536180-704c-11ea-8665-0fc02a07aac9.png)

![Typography Reference Image](https://trello-attachments.s3.amazonaws.com/5db12c4da582b82f206fdb3e/5e7bed50d30cac674abd106e/de71c1c7b0a90c4320ee1f2563429e1c/Typography.png)

---
TODO
- [x] Test every style, add image of results

_Test using the PR template of #49_