### PR TITLE
Four application/account status yellow screens

### DIFF
--- a/src/routes/Route.tsx
+++ b/src/routes/Route.tsx
@@ -13,6 +13,8 @@ import RegistrationScreen from '../screens/RegistrationScreen';
 import TermsScreen from '../screens/TermsScreen';
 import ApplicationApprovedScreen from '../screens/ApplicationApprovedScreen';
 import ApplicationPendingScreen from '../screens/ApplicationPendingScreen';
+import ApplicationIncompleteScreen from '../screens/ApplicationIncompleteScreen';
+import AccountSuspendedScreen from '../screens/AccountSuspendedScreen';
 import ContactScreen from '../screens/ContactScreen';
 import LoginSuccessScreen from '../screens/LoginSuccessScreen';
 import DonationScreen from '../screens/DashboardScreen/DonationScreen';
@@ -122,6 +124,8 @@ export const FullAppStack = createStackNavigator(
 		TermsScreen,
 		ApplicationApprovedScreen,
 		ApplicationPendingScreen,
+		ApplicationIncompleteScreen,
+		AccountSuspendedScreen,
 		ContactScreen,
 		Drawer,
 	},

--- a/src/routes/Route.tsx
+++ b/src/routes/Route.tsx
@@ -11,10 +11,6 @@ import LoginScreen from '../screens/LoginScreen';
 import DashboardScreen from '../screens/DashboardScreen';
 import RegistrationScreen from '../screens/RegistrationScreen';
 import TermsScreen from '../screens/TermsScreen';
-import ApplicationApprovedScreen from '../screens/ApplicationApprovedScreen';
-import ApplicationPendingScreen from '../screens/ApplicationPendingScreen';
-import ApplicationIncompleteScreen from '../screens/ApplicationIncompleteScreen';
-import AccountSuspendedScreen from '../screens/AccountSuspendedScreen';
 import ContactScreen from '../screens/ContactScreen';
 import LoginSuccessScreen from '../screens/LoginSuccessScreen';
 import DonationScreen from '../screens/DashboardScreen/DonationScreen';
@@ -122,10 +118,6 @@ export const FullAppStack = createStackNavigator(
 		LoginScreen,
 		RegistrationScreen,
 		TermsScreen,
-		ApplicationApprovedScreen,
-		ApplicationPendingScreen,
-		ApplicationIncompleteScreen,
-		AccountSuspendedScreen,
 		ContactScreen,
 		Drawer,
 	},

--- a/src/screens/AccountSuspendedScreen/AccountSuspendedScreen.tsx
+++ b/src/screens/AccountSuspendedScreen/AccountSuspendedScreen.tsx
@@ -3,22 +3,23 @@ import React from 'react';
 import InfoScreen from '../InfoScreen';
 
 export default () => (
-  <InfoScreen
-    title='Your account is suspended. ):'
-    nextScreenTitle='Contact Us'
-    nextScreenDestination='ContactScreen'
-  >
-    <Paragraph>
+	<InfoScreen
+		title="Your account is suspended. ):"
+		nextScreenTitle="Contact Us"
+		nextScreenDestination="ContactScreen"
+		showBackButton={false}
+	>
+		<Paragraph>
       Looks like your application didn't meet one of our requirements.
-    </Paragraph>
-    <SpacerInline height={20} />
-    <Paragraph>
+		</Paragraph>
+		<SpacerInline height={20} />
+		<Paragraph>
       Please expect to receive a call from us within 24-48 hours regarding your
       account.
-    </Paragraph>
-    <SpacerInline height={20} />
-    <Paragraph>
+		</Paragraph>
+		<SpacerInline height={20} />
+		<Paragraph>
       If you don't hear from us, please contact us via email.
-    </Paragraph>
-  </InfoScreen>
+		</Paragraph>
+	</InfoScreen>
 );

--- a/src/screens/ApplicationApprovedScreen/ApplicationApprovedScreen.tsx
+++ b/src/screens/ApplicationApprovedScreen/ApplicationApprovedScreen.tsx
@@ -5,22 +5,23 @@ import React from 'react';
 import InfoScreen from '../InfoScreen';
 
 export default ({ id }: { id: string }) => {
-  setAccountToActive({ id });
+	setAccountToActive({ id });
 
-  return (
-    <InfoScreen
-      title='Your application is approved! (:'
-      nextScreenTitle='Start'
-      nextScreenDestination='DashboardScreen'
-    >
-      <Paragraph>
+	return (
+		<InfoScreen
+			title="Your application is approved! (:"
+			nextScreenTitle="Start"
+			nextScreenDestination="DashboardScreen"
+			showBackButton={false}
+		>
+			<Paragraph>
         Welcome to the Banana App! We are so excited to have you join our
         family.
-      </Paragraph>
-      <SpacerInline height={40} />
-      <Paragraph emphasized={true}>
+			</Paragraph>
+			<SpacerInline height={40} />
+			<Paragraph emphasized={true}>
         CLICK "START" TO BEGIN YOUR FIRST DONATION!
-      </Paragraph>
-    </InfoScreen>
-  );
+			</Paragraph>
+		</InfoScreen>
+	);
 };

--- a/src/screens/ApplicationApprovedScreen/ApplicationApprovedScreen.tsx
+++ b/src/screens/ApplicationApprovedScreen/ApplicationApprovedScreen.tsx
@@ -5,22 +5,22 @@ import React from 'react';
 import InfoScreen from '../InfoScreen';
 
 export default ({ id }: { id: string }) => {
-	setAccountToActive({ id });
+  setAccountToActive({ id });
 
-	return (
-		<InfoScreen
-			title="Your application is approved!"
-			nextScreenTitle="Start"
-			nextScreenDestination="DashboardScreen"
-		>
-			<Paragraph>
+  return (
+    <InfoScreen
+      title='Your application is approved! (:'
+      nextScreenTitle='Start'
+      nextScreenDestination='DashboardScreen'
+    >
+      <Paragraph>
         Welcome to the Banana App! We are so excited to have you join our
         family.
-			</Paragraph>
-			<SpacerInline height={40} />
-			<Paragraph emphasized={true}>
+      </Paragraph>
+      <SpacerInline height={40} />
+      <Paragraph emphasized={true}>
         CLICK "START" TO BEGIN YOUR FIRST DONATION!
-			</Paragraph>
-		</InfoScreen>
-	);
+      </Paragraph>
+    </InfoScreen>
+  );
 };

--- a/src/screens/ApplicationIncompleteScreen/ApplicationIncompleteScreen.tsx
+++ b/src/screens/ApplicationIncompleteScreen/ApplicationIncompleteScreen.tsx
@@ -1,20 +1,23 @@
-import { Paragraph } from '@elements';
+import { Paragraph, SpacerInline } from '@elements';
 import React from 'react';
 import InfoScreen from '../InfoScreen';
 
 export default () => (
-  <InfoScreen
-    title='Your account is incomplete. ):'
-    nextScreenTitle='Contact Us'
-    nextScreenDestination='ContactScreen'
-  >
-    <Paragraph>Looks like your application needs further review.</Paragraph>
-    <Paragraph>
+	<InfoScreen
+		title="Your account is incomplete. ):"
+		nextScreenTitle="Contact Us"
+		nextScreenDestination="ContactScreen"
+		showBackButton={false}
+	>
+		<Paragraph>Looks like your application needs further review.</Paragraph>
+		<SpacerInline height={20} />
+		<Paragraph>
       Please expect to receive a call from us within 24-48 hours regarding your
       account.
-    </Paragraph>
-    <Paragraph>
+		</Paragraph>
+		<SpacerInline height={20} />
+		<Paragraph>
       If you don't hear from us, please contact us via email.
-    </Paragraph>
-  </InfoScreen>
+		</Paragraph>
+	</InfoScreen>
 );

--- a/src/screens/ApplicationIncompleteScreen/ApplicationIncompleteScreen.tsx
+++ b/src/screens/ApplicationIncompleteScreen/ApplicationIncompleteScreen.tsx
@@ -1,22 +1,18 @@
-import { Paragraph, SpacerInline } from '@elements';
+import { Paragraph } from '@elements';
 import React from 'react';
 import InfoScreen from '../InfoScreen';
 
 export default () => (
   <InfoScreen
-    title='Your account is suspended. ):'
+    title='Your account is incomplete. ):'
     nextScreenTitle='Contact Us'
     nextScreenDestination='ContactScreen'
   >
-    <Paragraph>
-      Looks like your application didn't meet one of our requirements.
-    </Paragraph>
-    <SpacerInline height={20} />
+    <Paragraph>Looks like your application needs further review.</Paragraph>
     <Paragraph>
       Please expect to receive a call from us within 24-48 hours regarding your
       account.
     </Paragraph>
-    <SpacerInline height={20} />
     <Paragraph>
       If you don't hear from us, please contact us via email.
     </Paragraph>

--- a/src/screens/ApplicationIncompleteScreen/index.ts
+++ b/src/screens/ApplicationIncompleteScreen/index.ts
@@ -1,0 +1,3 @@
+import AccountIncompleteScreen from './ApplicationIncompleteScreen';
+
+export default AccountIncompleteScreen;

--- a/src/screens/ApplicationPendingScreen/ApplicationPendingScreen.tsx
+++ b/src/screens/ApplicationPendingScreen/ApplicationPendingScreen.tsx
@@ -4,16 +4,17 @@ import React from 'react';
 import InfoScreen from '../InfoScreen';
 
 export default () => (
-  <InfoScreen
-    title='Your application is being reviewed.'
-    nextScreenTitle='Learn More'
-    nextScreenDestination='HelpScreen'
-  >
-    <Paragraph>
+	<InfoScreen
+		title="Your application is being reviewed."
+		nextScreenTitle="Learn More"
+		nextScreenDestination="HelpScreen"
+		showBackButton={false}
+	>
+		<Paragraph>
       Please allow 24-48 hours for your registration to be reviewed. We will
       send you an email once the application has been processed.
-    </Paragraph>
-    <SpacerInline height={40} />
-    <Paragraph emphasized={true}>THANK YOU!</Paragraph>
-  </InfoScreen>
+		</Paragraph>
+		<SpacerInline height={40} />
+		<Paragraph emphasized={true}>THANK YOU!</Paragraph>
+	</InfoScreen>
 );

--- a/src/screens/ApplicationPendingScreen/ApplicationPendingScreen.tsx
+++ b/src/screens/ApplicationPendingScreen/ApplicationPendingScreen.tsx
@@ -4,16 +4,16 @@ import React from 'react';
 import InfoScreen from '../InfoScreen';
 
 export default () => (
-	<InfoScreen
-		title="Your application is being reviewed."
-		nextScreenTitle="Learn More"
-		nextScreenDestination="ApplicationApprovedScreen"
-	>
-		<Paragraph>
-			Please allow 24-48 hours for your registration to be reviewed. We will
+  <InfoScreen
+    title='Your application is being reviewed.'
+    nextScreenTitle='Learn More'
+    nextScreenDestination='HelpScreen'
+  >
+    <Paragraph>
+      Please allow 24-48 hours for your registration to be reviewed. We will
       send you an email once the application has been processed.
-		</Paragraph>
-		<SpacerInline height={40} />
-		<Paragraph emphasized={true}>THANK YOU!</Paragraph>
-	</InfoScreen>
+    </Paragraph>
+    <SpacerInline height={40} />
+    <Paragraph emphasized={true}>THANK YOU!</Paragraph>
+  </InfoScreen>
 );

--- a/src/screens/ContactScreen/ContactScreen.tsx
+++ b/src/screens/ContactScreen/ContactScreen.tsx
@@ -7,10 +7,10 @@ import styles from './ContactScreen.styles';
 export default () => (
 	<InfoScreen
 		title="Contact."
-		backDestination="ApplicationPendingScreen"
 	>
 		<Text style={styles.documentText}>
-			Please allow 24-48 hours for your registration to complete.  The app will open when your application is processed.
+			Please allow 24-48 hours for your registration to complete.
+			The app will open when your application is processed.
 		</Text>
 		<SpacerInline height={25} />
 		<Text style={styles.headingText}>

--- a/src/screens/InfoScreen/InfoScreen.tsx
+++ b/src/screens/InfoScreen/InfoScreen.tsx
@@ -1,11 +1,8 @@
-import React, { FunctionComponent, ReactChild } from 'react';
-import { View } from 'react-native';
 import {
-	Title,
-	LinkButton,
-	SpacerInline,
-	Header,
+	Header, LinkButton, SpacerInline, Title,
 } from '@elements';
+import React, { FunctionComponent } from 'react';
+import { View } from 'react-native';
 import styles from './InfoScreen.styles';
 
 type InfoScreenProps = {
@@ -13,7 +10,7 @@ type InfoScreenProps = {
 	nextScreenTitle?: string;
 	nextScreenDestination?: string;
 	backDestination?: string;
-	children?: ReactChild | ReactChild[];
+	showBackButton?: boolean;
 };
 
 const InfoScreen: FunctionComponent<InfoScreenProps> = ({
@@ -21,11 +18,12 @@ const InfoScreen: FunctionComponent<InfoScreenProps> = ({
 	nextScreenTitle,
 	nextScreenDestination,
 	backDestination,
+	showBackButton,
 	children,
-}: InfoScreenProps) => (
+}) => (
 	<View style={styles.outerContainer}>
 		<View>
-			<Header showMenu={false} backDestination={backDestination} />
+			<Header showMenu={false} showBackButton={showBackButton} backDestination={backDestination} />
 			<Title text={title} />
 			<SpacerInline height={20} />
 			<View>

--- a/src/screens/LoginScreen/LoginScreen.tsx
+++ b/src/screens/LoginScreen/LoginScreen.tsx
@@ -31,7 +31,7 @@ export default () => {
 		switch (statusCode) {
 			case 202: {
 				await clearEmailAndPassword();
-				navigate('AccountSuspendedScreen');
+				navigate('LoginSuccessScreen');
 				return;
 			}
 			case 401: Alert.alert('Incorrect email or password'); return;

--- a/src/screens/LoginScreen/LoginScreen.tsx
+++ b/src/screens/LoginScreen/LoginScreen.tsx
@@ -31,7 +31,7 @@ export default () => {
 		switch (statusCode) {
 			case 202: {
 				await clearEmailAndPassword();
-				navigate('LoginSuccessScreen');
+				navigate('AccountSuspendedScreen');
 				return;
 			}
 			case 401: Alert.alert('Incorrect email or password'); return;

--- a/src/screens/LoginSuccessScreen/LoginSuccessScreen.tsx
+++ b/src/screens/LoginSuccessScreen/LoginSuccessScreen.tsx
@@ -5,6 +5,7 @@ import InfoScreen from '../InfoScreen';
 import AccountSuspendedScreen from '../AccountSuspendedScreen';
 import ApplicationPendingScreen from '../ApplicationPendingScreen';
 import ApplicationApprovedScreen from '../ApplicationApprovedScreen';
+import ApplicationIncompleteScreen from '../ApplicationIncompleteScreen';
 import DashboardScreen from '../DashboardScreen';
 
 export default () => {
@@ -15,6 +16,7 @@ export default () => {
 	if (!jwt || !user) { return <Text>Loading...</Text>; }
 
 	switch (user?.account_status) {
+		case 'incomplete': return <ApplicationIncompleteScreen />;
 		case 'suspended': return <AccountSuspendedScreen />;
 		case 'pending': return <ApplicationPendingScreen />;
 		case 'approved': return <ApplicationApprovedScreen id={id} />;

--- a/src/screens/LogoutScreen/LogoutScreen.tsx
+++ b/src/screens/LogoutScreen/LogoutScreen.tsx
@@ -7,6 +7,7 @@ export default () => (
 		title="You are logged out."
 		nextScreenTitle="Log In"
 		nextScreenDestination="LoginScreen"
+		showBackButton={false}
 	>
 		<Paragraph>We hope to see you soon!</Paragraph>
 	</InfoScreen>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
- added Application Incomplete yellow screen
- edited the text on all four application/account yellow screens based on Figma (emojis, additional lines, etc)
- added showBackButton prop to InfoScreen based on Header component, so the Back button does not show on the yellow screens per Figma
- Contact page (which uses InfoScreen) does have Back button, so I changed code to allow for Back button to have goBack() functionality by setting backDestination=null which then defaults to goBack()

**What is the current behavior? (You can also link to an open issue here)**
- prior to this PR there is no Application Incomplete screen, and the other yellow screens are not updated according to Figma.  Back buttons are visible (and not functional).  Yellow screens with "Learn More" button aren't linked to Contact screen. Contact screen back button does not work.

**What is the new behavior? (if this is a feature change)**
- with this PR: based on account status, if it is not active, after logging in the user will see the corresponding yellow screen (acct suspended, application incomplete, etc).  No back button, user can click on "Learn More" which takes them to Contact Screen.  Can go back to previous yellow screen from Contact Screen.

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
- not aware of any breaking changes.  the only additional yellow screen that uses InfoScreen is Contact screen and I confirmed working Back button functionality
