### PR TITLE
[BUG] Fix Button when wrapping composite component children

### DIFF
--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -6,6 +6,7 @@ import {
 	TouchableHighlight,
 	TouchableHighlightProps,
 	ViewStyle,
+	View,
 } from 'react-native';
 import {
 	ColorScheme,
@@ -89,9 +90,14 @@ export default ({
 			onHideUnderlay={() => { setPressed(false); onHideUnderlay(); }}
 			{...props}
 		>
-			{
-				children(foregroundColor)
-			}
+			{/**
+			  * View is required in order for native props to pass down to children properly.
+			  */}
+			<View>
+				{
+					children(foregroundColor)
+				}
+			</View>
 		</TouchableHighlight>
 	);
 };

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -5,21 +5,29 @@ import React, { useState } from 'react';
 import {
 	TouchableHighlight,
 	TouchableHighlightProps,
-	ViewStyle,
 	View,
+	ViewStyle,
 } from 'react-native';
 import {
 	ColorScheme,
 	useScheme,
 } from '@util/colorSchemes';
-import { DARK_GRAY_TRANSPARENT, WHITE } from '@util/colors';
+import {
+	DARK_GRAY_TRANSPARENT,
+	WHITE,
+} from '@util/colors';
 import styles from './Button.styles';
 import { ButtonStyle } from './index';
 
 export type ButtonProps = TouchableHighlightProps & {
-	children: (foregroundColor: string) => React.ReactNode; // Elements to be wrapped by the button.
-	buttonStyle: ButtonStyle; // Styles for different button states.
-	outlined?: boolean; // Whether the button is styled with an outline and transparent body.
+	/** Render function that results in elements to be wrapped by the button. */
+	children: (foregroundColor: string) => React.ReactNode;
+
+	/** Styles for different button states. */
+	buttonStyle: ButtonStyle;
+
+	/** Whether the button is styled with an outline and transparent body. */
+	outlined?: boolean;
 };
 
 export default ({


### PR DESCRIPTION
Currently, using a composite component (nearly every component we make) within a button breaks the app.

```tsx
<Button buttonStyle={buttonStyle}>
	{foregroundColor => (<Icon size={20} color={foregroundColor} name="bell" />)}
</Button>
```

This now works.