### PR TITLE
Remove Dangerous NPM Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "web": "expo start --web",
     "eject": "expo eject",
     "lint": "eslint --quiet --ext .tsx,.ts,.js .",
-    "typechecking": "tsc --noEmit",
-    "reset": "rm -rf ./node_modules && rm package-lock.json && npm i && watchman watch-del-all"
+    "typechecking": "tsc --noEmit"
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",


### PR DESCRIPTION
The NPM scripts include a 'reset' script that deletes the package-lock file.

This deletion is not something to take lightly since this file ensures the multitude of our dependencies are at specific versions, that when combined, make our product work. Deleting the file and then running `npm install` could alter the versions of deep dependencies and break the app.