### PR TITLE
add safeAreaView to wrap all the screen at App.tsx

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Text, View, YellowBox } from 'react-native';
+import {
+	SafeAreaView, Text, View, YellowBox,
+} from 'react-native';
 import { Provider } from 'react-native-paper';
 import { AppearanceProvider } from 'react-native-appearance';
 import Constants from 'expo-constants';
@@ -46,10 +48,10 @@ export default function App() {
 			{/* All elements within AppearanceProvider will have access
 			 *  to the user-defined OS color theme preference: 'light', 'dark', 'no-preference'. */}
 			<Provider>
-				<View style={styles.container}>
+				<SafeAreaView style={styles.container}>
 					<Route ref={navRef => NavigationService.setTopLevelNavigator(navRef)} />
 					<TheAlertModal />
-				</View>
+				</SafeAreaView>
 			</Provider>
 		</AppearanceProvider>
 	);


### PR DESCRIPTION
Previously, we check the platform in Header component and add marginTop to fit for some screen having notch like iPhone X. But it might not work with some old models like iPhone SE.

In updating Header to NavBar, I found the component SafeAreaView could work better on fitting different devices, and after discussion with @jacksonrya, we agree that we could put SafeAreaView at the most external level, which is at App.tsx, to wrap all screens so devs do not need to use SafeAreaView component in every screen. 

So all screens would be the same if this PR and NavBar PR are merged. Currently, if you only look at this PR, there would be double margin at the top since the old mechanism of Header is still working.