### PR TITLE
infoscreen padding layout

### DIFF
--- a/src/screens/InfoScreen/InfoScreen.styles.ts
+++ b/src/screens/InfoScreen/InfoScreen.styles.ts
@@ -4,22 +4,10 @@ import * as colors from '@util/colors';
 export default StyleSheet.create({
 	outerContainer: {
 		flex: 1,
+		flexDirection: 'column',
 		justifyContent: 'space-between',
+		alignItems: 'center',
 		backgroundColor: colors.BANANA_YELLOW,
-		paddingHorizontal: '11%',
-	},
-	input: {
-		height: 50,
-		marginBottom: 15,
-	},
-	documentContainer: {
-		backgroundColor: 'white',
-		paddingHorizontal: '5%',
-	},
-	documentText: {
-		fontFamily: 'open-sans-regular',
-		color: colors.NAVY_BLUE,
-		fontSize: 13,
-		textAlign: 'justify',
+		padding: 40,
 	},
 });

--- a/src/screens/InfoScreen/InfoScreen.tsx
+++ b/src/screens/InfoScreen/InfoScreen.tsx
@@ -1,5 +1,5 @@
 import {
-	NavBar, LinkButton, SpacerInline, Title,
+	LinkButton, SpacerInline, Title,
 } from '@elements';
 import React, { FunctionComponent } from 'react';
 import { View } from 'react-native';
@@ -17,15 +17,12 @@ const InfoScreen: FunctionComponent<InfoScreenProps> = ({
 	title,
 	nextScreenTitle,
 	nextScreenDestination,
-	backDestination,
-	showBackButton,
 	children,
 }) => (
 	<View style={styles.outerContainer}>
 		<View>
-			<NavBar showMenu={false} showBackButton={showBackButton} backDestination={backDestination} />
 			<Title text={title} />
-			<SpacerInline height={20} />
+			<SpacerInline height={40} />
 			<View>
 				{children}
 			</View>
@@ -35,7 +32,6 @@ const InfoScreen: FunctionComponent<InfoScreenProps> = ({
 			{ nextScreenTitle && nextScreenDestination && (
 				<LinkButton text={nextScreenTitle} destination={nextScreenDestination} />
 			)}
-			<SpacerInline height={40} />
 		</View>
 	</View>
 );


### PR DESCRIPTION
The main purpose of this PR is to reformat the yellow screens (Application Pending/Incomplete/Approved/Suspended, and Logout) - specifically the `InfoScreen` component (PR [#55](https://github.com/FoodIsLifeBGP/banana-rn/pull/55)) based on layout change with NavBar (PR [#64](https://github.com/FoodIsLifeBGP/banana-rn/pull/64)).  

## Previous
<img width="410" alt="former" src="https://user-images.githubusercontent.com/44376276/81609411-b3d4e580-938c-11ea-95e6-3a53ecb6a16d.png">
<img width="403" alt="Screen Shot 2020-05-09 at 1 25 52 PM" src="https://user-images.githubusercontent.com/44376276/81609419-b7686c80-938c-11ea-8dd5-4fc50105f8e2.png">

## With PR Changes
<img width="444" alt="Screen Shot 2020-05-09 at 1 44 06 PM" src="https://user-images.githubusercontent.com/44376276/81609522-e7177480-938c-11ea-8253-0200cc1c5cdb.png">
<img width="429" alt="Screen Shot 2020-05-09 at 1 43 50 PM" src="https://user-images.githubusercontent.com/44376276/81609534-eed71900-938c-11ea-8ae9-f8e744bdd9be.png">

- Removed `paddingHorizonal: 11%`

- Removed `NavBar` from `InfoScreen`
    - I decided to make this change because out of all the screens using `InfoScreen`, only 
      `ContactScreen` does, and based on Figma we will be updating `ContactScreen` with a new 
       design that does not appear to be using `InfoScreen` (will be same layout as `Tutorials`, 
      `FAQs`).

## Future Considerations
Will need to finalize font size, as current code does not match exactly with Figma.  I found that when I increased font size to match, it affected use of `Title` elsewhere in the app.  We could consider adding a font size prop to `Title` but I will leave that for future discussion!