### PR TITLE
[TR#196] Circle Image Form Input

### DIFF
--- a/src/elements/FormImageInput/FormImageInput.styles.tsx
+++ b/src/elements/FormImageInput/FormImageInput.styles.tsx
@@ -21,6 +21,11 @@ export default StyleSheet.create({
 		width: '100%',
 		aspectRatio: 2.25,
 	},
+	circularImage: {
+		width: 140,
+		height: 140,
+		borderRadius: 140 / 2,
+	},
 	iconContainer: {
 		justifyContent: 'center',
 		alignItems: 'center',
@@ -28,6 +33,16 @@ export default StyleSheet.create({
 		height: 140,
 		borderColor: colors.NAVY_BLUE,
 		borderWidth: 4,
+		backgroundColor: colors.WHITE_TRANSPARENT,
+	},
+	iconCircularContainer: {
+		justifyContent: 'center',
+		alignItems: 'center',
+		width: 140,
+		height: 140,
+		borderRadius: 140 / 2,
+		borderWidth: 4,
+		borderColor: colors.NAVY_BLUE,
 		backgroundColor: colors.WHITE_TRANSPARENT,
 	},
 	statusRowText: {

--- a/src/elements/FormImageInput/FormImageInput.tsx
+++ b/src/elements/FormImageInput/FormImageInput.tsx
@@ -95,8 +95,9 @@ const FormImageInput = (
 			>
 				{ value?.uri != null
 					? (
+						//console.log(style.circularImage);
 						<Image
-							style={shape === 'rectangular' ? styles.image : style.circularImage}
+							style={shape === 'rectangular' ? styles.image : styles.circularImage}
 							source={{ uri: value.uri }}
 						/>
 					)

--- a/src/elements/FormImageInput/FormImageInput.tsx
+++ b/src/elements/FormImageInput/FormImageInput.tsx
@@ -95,7 +95,6 @@ const FormImageInput = (
 			>
 				{ value?.uri != null
 					? (
-						//console.log(style.circularImage);
 						<Image
 							style={shape === 'rectangular' ? styles.image : styles.circularImage}
 							source={{ uri: value.uri }}

--- a/src/elements/FormImageInput/FormImageInput.tsx
+++ b/src/elements/FormImageInput/FormImageInput.tsx
@@ -43,6 +43,9 @@ interface FormImageInputProps {
 
 	/** User-facing message associated with an error. */
 	errorMessage?: string;
+
+	/** Shape of the image input */
+	shape?: 'rectangular' | 'circular';
 }
 
 const MessageFromStatus = {
@@ -64,6 +67,7 @@ const FormImageInput = (
 		style,
 		error = false,
 		errorMessage,
+		shape = 'rectangular',
 	}: FormImageInputProps,
 	ref: Ref<TouchableWithoutFeedback>,
 ) => {
@@ -92,12 +96,12 @@ const FormImageInput = (
 				{ value?.uri != null
 					? (
 						<Image
-							style={styles.image}
+							style={shape === 'rectangular' ? styles.image : style.circularImage}
 							source={{ uri: value.uri }}
 						/>
 					)
 					: (
-						<View style={styles.iconContainer}>
+						<View style={shape === 'rectangular' ? styles.iconContainer : styles.iconCircularContainer}>
 							<Icon name="image" size={24} />
 						</View>
 					)}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Add an option to the image input interface that would define the shape of input.

**New behavior**
<img width="386" alt="截圖 2020-06-05 下午9 57 18" src="https://user-images.githubusercontent.com/17737059/83951345-754d1200-a7f6-11ea-97e8-b1f9a3d3781f.png">

<img width="160" alt="截圖 2020-06-06 下午1 47 13" src="https://user-images.githubusercontent.com/17737059/83952134-446fdb80-a7fc-11ea-96dc-e16a351db34e.png">

- usage example
```
<FormImageInput
	label="Business License Verification"
	value={image}
	setValue={setImage}
	status={image?.uri ? 'success' : 'none'}
	shape="circular"
/>
```

