### PR TITLE
TR_186 Add/Modify Contact Screen for PreAlpha

### DIFF
--- a/src/elements/ContentHeader/ContentHeader.styles.ts
+++ b/src/elements/ContentHeader/ContentHeader.styles.ts
@@ -1,0 +1,24 @@
+import { StyleSheet } from 'react-native';
+import typography from '@util/typography';
+import * as Colors from '@util/colors';
+
+export default StyleSheet.create({
+	headerContainer: {
+		flexBasis: 'auto',
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: Colors.BANANA_YELLOW,
+	},
+	smallHeaderText: {
+		...typography.h3,
+	},
+	largeHeaderText: {
+		...typography.h1,
+	},
+	smallHeaderContainer: {
+		height: 104,
+	},
+	largeHeaderContainer: {
+		height: 180,
+	},
+});

--- a/src/elements/ContentHeader/ContentHeader.tsx
+++ b/src/elements/ContentHeader/ContentHeader.tsx
@@ -1,0 +1,43 @@
+
+import React from 'react';
+import {
+	Text,
+	View,
+	StyleProp,
+	ViewStyle,
+	TextStyle,
+} from 'react-native';
+import styles from './ContentHeader.styles';
+
+export type HeaderSize = 'small' | 'large';
+
+// TODO: add props that allow client to select, small(ContactScreen) vs large header(LoginScreen)
+interface ContentHeaderProps {
+	title: string;
+	style?: StyleProp<ViewStyle>;
+	textStyle?: StyleProp<TextStyle>;
+	headerSize?: HeaderSize;
+}
+
+export default ({
+	title,
+	style,
+	textStyle,
+	headerSize = 'small',
+}: ContentHeaderProps) => {
+	const sizedContainerStyle = headerSize === 'small'
+		? styles.smallHeaderContainer
+		: styles.largeHeaderContainer;
+
+	const sizedTextStyle = headerSize === 'small'
+		? styles.smallHeaderText
+		: styles.largeHeaderText;
+
+	return (
+		<View style={[styles.headerContainer, sizedContainerStyle, style]}>
+			<Text style={[sizedTextStyle, textStyle]}>
+				{title}
+			</Text>
+		</View>
+	);
+};

--- a/src/elements/ContentHeader/index.ts
+++ b/src/elements/ContentHeader/index.ts
@@ -1,0 +1,3 @@
+import ContentHeader from './ContentHeader';
+
+export { ContentHeader };

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -12,3 +12,4 @@ export { Paragraph } from './Paragraph';
 export { Modal } from './Modal';
 export { TheAlertModal } from './TheAlertModal';
 export { EmptyStateView } from './EmptyStateView';
+export { ContentHeader } from './ContentHeader';

--- a/src/routes/Route.tsx
+++ b/src/routes/Route.tsx
@@ -40,6 +40,7 @@ export const MainStack = createStackNavigator(
 		QRCodeScannerScreen,
 		ClaimDetailScreen,
 		DonationsDetailScreen,
+		ContactScreen,
 	},
 	{
 		headerMode: 'none',
@@ -92,10 +93,18 @@ const donorOrClientDrawer = () => {
 				drawerIcon: DrawerIcon('settings'),
 			},
 		},
-		HelpScreen: {
-			screen: MainStack,
+		// TODO: This will likely be implemented in alpha+ versions
+		// HelpScreen: {
+		// screen: MainStack,
+		// navigationOptions: {
+		// drawerLabel: 'Help',
+		// drawerIcon: DrawerIcon('help'),
+		// },
+		// },
+		ContactScreen: {
+			screen: ContactScreen,
 			navigationOptions: {
-				drawerLabel: 'Help',
+				drawerLabel: 'Contact Us',
 				drawerIcon: DrawerIcon('help'),
 			},
 		},

--- a/src/screens/ContactScreen/ContactScreen.styles.ts
+++ b/src/screens/ContactScreen/ContactScreen.styles.ts
@@ -1,15 +1,66 @@
 import { StyleSheet } from 'react-native';
-import * as colors from '@util/colors';
+import * as Colors from '@util/colors';
+import typography from '@util/typography';
+
+const GRID_MARGIN = 20; // Grid One from Style Guide TODO: make grid constants global
+const LIST_ITEM_BORDER_COLOR = Colors.LIGHT_GRAY;
+
+export const ListItem = StyleSheet.create({
+	container: {
+		paddingHorizontal: GRID_MARGIN,
+		paddingVertical: 10,
+		borderWidth: 1,
+		borderStyle: 'solid',
+		borderColor: 'transparent',
+		borderBottomColor: LIST_ITEM_BORDER_COLOR,
+	},
+	firstContainer: {
+		borderTopColor: LIST_ITEM_BORDER_COLOR,
+	},
+	title: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		marginBottom: 5,
+	},
+	titleText: {
+		...typography.h3,
+	},
+	titleIcon: {
+		marginRight: 12,
+	},
+	message: {
+		...typography.body1,
+	},
+});
 
 export default StyleSheet.create({
-	headingText: {
-		fontFamily: 'open-sans-bold',
-		fontSize: 20,
-		color: colors.NAVY_BLUE,
+	outerContainer: {
+		flex: 1,
 	},
-	documentText: {
-		fontFamily: 'open-sans-regular',
-		fontSize: 14,
-		color: colors.NAVY_BLUE,
+	header: {
+		flexBasis: '16%',
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: Colors.BANANA_YELLOW,
+	},
+	headerText: {
+		...typography.h3,
+	},
+	bodyContainer: {
+		flex: 1,
+	},
+	bodyMessage: {
+		paddingHorizontal: GRID_MARGIN, // TODO: update based on Figma Question #65
+		paddingVertical: GRID_MARGIN,
+	},
+	bodyMessageTitle: {
+		...typography.h3,
+		alignSelf: 'center',
+		padding: GRID_MARGIN,
+	},
+	bodyMessageBody: {
+		...typography.body1,
+		paddingBottom: GRID_MARGIN,
+		textAlign: 'center',
 	},
 });

--- a/src/screens/ContactScreen/ContactScreen.tsx
+++ b/src/screens/ContactScreen/ContactScreen.tsx
@@ -1,32 +1,120 @@
 import React from 'react';
-import { Text } from 'react-native';
-import { SpacerInline } from '@elements';
-import InfoScreen from '../InfoScreen';
-import styles from './ContactScreen.styles';
+import {
+	ScrollView,
+	Text,
+	TouchableHighlight,
+	View,
+} from 'react-native';
+import { Linking } from 'expo';
+import {
+	ContentHeader,
+	NavBar,
+	SpacerInline,
+	LinkButton,
+	Icon,
+} from '@elements';
+import { IconName } from '@elements/Icon';
+import { useNavigation } from 'react-navigation-hooks';
+import useGlobal from '@state';
+import styles, { ListItem } from './ContactScreen.styles';
 
-export default () => (
-	<InfoScreen
-		title="Contact."
-	>
-		<Text style={styles.documentText}>
-			Please allow 24-48 hours for your registration to complete.
-			The app will open when your application is processed.
-		</Text>
-		<SpacerInline height={25} />
-		<Text style={styles.headingText}>
-			CALL US
-		</Text>
-		<SpacerInline height={5} />
-		<Text style={styles.documentText}>
-			206-209-0555
-		</Text>
-		<SpacerInline height={25} />
-		<Text style={styles.headingText}>
-			EMAIL US
-		</Text>
-		<SpacerInline height={5} />
-		<Text style={styles.documentText}>
-			admin@thebananaapp.org
-		</Text>
-	</InfoScreen>
-);
+const contactList: Array<{
+	title: string;
+	message: string;
+	link: string;
+	iconName: IconName;
+}> = [
+	{
+		title: 'website',
+		message: 'www.bananaapp.org',
+		link: 'https://www.bananaapp.org',
+		iconName: 'website',
+	},
+	{
+		title: 'email',
+		message: 'info@bananapp.org',
+		// TODO: When the default iOS email app is uninstalled, this fails.
+		link: 'mailto:info@bananapp.org',
+		iconName: 'email',
+	},
+	{
+		title: 'facebook',
+		message: 'Connect with us on Facebook!',
+		link: 'https://facebook.com/BeGoodProject',
+		iconName: 'facebook',
+	},
+];
+
+interface ContactScreenParams {
+	backDestination?: string;
+}
+
+export default ({ backDestination }: ContactScreenParams) => {
+	const { navigate, goBack } = useNavigation();
+	const [ state, { updateAlert } ] = useGlobal() as any;
+
+	const openLink = async (url: string) => {
+		const supported = await Linking.canOpenURL(url);
+
+		supported
+			? await Linking.openURL(url)
+			: updateAlert({
+				title: 'Oops!',
+				message: `There was an error connecting to ${url}-- please try again later.`,
+				dismissable: true,
+			});
+	};
+
+	return (
+		<View style={styles.outerContainer}>
+			<NavBar />
+
+			<ContentHeader headerSize="large" title="Contact Us" />
+
+			<ScrollView style={styles.bodyContainer}>
+				{/* Body Message */}
+				<View style={styles.bodyMessage}>
+					<Text style={styles.bodyMessageTitle}>
+						We are here to help.
+					</Text>
+
+					<Text style={styles.bodyMessageBody}>
+						{
+							'Feel free to reach out to us with any questions or inquiries!'
+							+ ' \nWe will get back to you in 1-2 business days.'
+						}
+					</Text>
+				</View>
+
+				{/* Contact List */}
+				<View>
+					{
+						contactList.map((contact, i) => (
+							<TouchableHighlight key={contact.title} onPress={() => openLink(contact.link)}>
+								<View style={[ ListItem.container, i === 0 && ListItem.firstContainer ]}>
+									<View style={ListItem.title}>
+										<View style={ListItem.titleIcon}>
+											<Icon name={contact.iconName} size={24} />
+										</View>
+
+										<Text style={ListItem.titleText}>
+											{contact.title}
+										</Text>
+									</View>
+
+									<Text style={ListItem.message}>
+										{contact.message}
+									</Text>
+								</View>
+							</TouchableHighlight>
+						))
+					}
+				</View>
+
+				<SpacerInline height={44} />
+				<LinkButton text="Back" onPress={backDestination ? () => navigate(backDestination) : () => goBack()} />
+
+			</ScrollView>
+		</View>
+	);
+};


### PR DESCRIPTION
# [TR_186] Add/Modify Contact (Formerly Help) Screen for PreAlpha
### _**NOTE: This PR makes use of code from #39**_ 

---

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Figma](https://www.figma.com/file/Kzv8b6CHHq5Y5aCuBWAGLU/THE-BANANA-APP-BGP?node-id=5374%3A1589)

### Pre Alpha Update: [TR 186](https://trello.com/c/iSPMbdGK/186-update-help-contact-us-screen)

### Original Help Screen: [TR 127](https://trello.com/c/UTiDbhMA/127-f-help-settings-w-text-sub-pages)

- The ask for the Help Screen has changed, some of the relevant code from PR 39 was used

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
- Add a Feature (New Screen)
- Add a Component (ContentHeader)

#### What is the current behavior? (You can also link to an open issue here)
- When a user clicks on the `Help` link in the menu drawer, they are redirected back to the Donations Screen (their Dashboard).

#### What is the new behavior? (if this is a feature change)
- The `Help Screen` was commented out and replaced with a `Contact Us` screen. Now when a user clicks the `Contact Us` link in the menu drawer, they are taken to a prealpha-ready Contact Page. 


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
- No breaking changes that I'm aware of!


#### Images (before/ after screenshots, interaction GIFs, ...)
![](https://media.giphy.com/media/WQT6Fa9pSKkfFYatfH/giphy.gif)

---

#### TODO:
If the user deletes their default iOS email app, a somewhat generic alert modal will popup. We'll likely want to handle this differently in future iterations.

