### PR TITLE
alertmodal should be null on empty alert(android)

### DIFF
--- a/src/elements/Modal/Modal.tsx
+++ b/src/elements/Modal/Modal.tsx
@@ -54,7 +54,7 @@ export default ({
 	return (
 		<View style={[
 			style,
-			styles.wrapper
+			styles.wrapper,
 		]}
 		>
 			<TouchableOpacity

--- a/src/elements/Modal/Modal.tsx
+++ b/src/elements/Modal/Modal.tsx
@@ -48,11 +48,13 @@ export default ({
 		}
 	};
 
+	// NOTE : null is returned here since using "display: none" does not work properly for android devices
+	if (!open) return null;
+
 	return (
 		<View style={[
 			style,
-			styles.wrapper,
-			!open && { display: 'none' },
+			styles.wrapper
 		]}
 		>
 			<TouchableOpacity

--- a/src/elements/TheAlertModal/TheAlertModal.tsx
+++ b/src/elements/TheAlertModal/TheAlertModal.tsx
@@ -29,7 +29,6 @@ export default () => {
 			clearAlert();
 		}
 	};
-	if (!alert) return null;
 	return (
 		<Modal
 			style={styles.container}

--- a/src/elements/TheAlertModal/TheAlertModal.tsx
+++ b/src/elements/TheAlertModal/TheAlertModal.tsx
@@ -29,7 +29,7 @@ export default () => {
 			clearAlert();
 		}
 	};
-
+	if (!alert) return null;
 	return (
 		<Modal
 			style={styles.container}


### PR DESCRIPTION
## Fix
Addresses issue when Android version couldn't dismiss AlertModals.
**Trello Card** [#205](https://trello.com/c/GBHgGUtn)
## How to test
* set initial Global state to have an alert
* ensure AlertModal is dismissable

