### PR TITLE
Let user know if the email they're using is already in the database

### DIFF
--- a/src/screens/RegistrationScreen/ClientRegistrationScreen.tsx
+++ b/src/screens/RegistrationScreen/ClientRegistrationScreen.tsx
@@ -101,6 +101,7 @@ export default () => {
 		switch (statusCode) {
 			case (201 || 202): Alert.alert('Registration complete! Please log in to continue.'); navigate('LoginScreen', { email, password }); return;
 			case 406: Alert.alert('Error: not accepted'); return;
+			case 409: Alert.alert('Email address is already in use. Try resetting your password?'); return;
 			case 500: Alert.alert('Internal server error, please try again later.'); return;
 			default: Alert.alert("Sorry, that didn't work, please try again later."); console.log(statusCode);
 		}

--- a/src/screens/RegistrationScreen/DonorRegistrationScreen.tsx
+++ b/src/screens/RegistrationScreen/DonorRegistrationScreen.tsx
@@ -57,6 +57,7 @@ export default () => {
 		switch (statusCode) {
 			case (201 || 202): Alert.alert('Registration complete! Please log in to continue.'); navigate('LoginScreen', { email, password }); return;
 			case 406: Alert.alert('Error: not accepted'); return;
+			case 409: Alert.alert('Email address is already in use. Try resetting your password?'); return;
 			case 500: Alert.alert('Internal server error, please try again later.'); return;
 			default: Alert.alert("Sorry, that didn't work, please try again later."); console.log(statusCode);
 		}

--- a/src/state/actions/register.ts
+++ b/src/state/actions/register.ts
@@ -78,9 +78,6 @@ export const registerClient = async (store, client: ClientRegisterProps) => {
 			[userIdentity]: {
 				email,
 				password,
-				first_name: firstName,
-				last_name: lastName,
-				account_status: 'pending',
 			},
 		}));
 		await store.setState({

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -9,12 +9,14 @@ const {
 	USER_IDENTITY,
 	API_BASE_URL,
 	LOGIN_URL,
+	CREATE_URL,
 } = getEnv();
 
 export const initialState: InitialState = {
 	userIdentity: USER_IDENTITY,
 	apiBaseUrl: API_BASE_URL,
 	loginUrl: LOGIN_URL,
+	createUrl: CREATE_URL,
 	alert: undefined,
 	donationsOrClaims: [],
 	jwt: undefined,

--- a/src/state/index.types.ts
+++ b/src/state/index.types.ts
@@ -73,6 +73,7 @@ export interface InitialState {
 	userIdentity: 'donor' | 'client';
 	apiBaseUrl: string;
 	loginUrl: string;
+	createUrl: string;
 	alert?: Alert;
 	jwt?: string;
 	user?: DonorState | ClientState | SharedProps;

--- a/src/util/constraints/clientRegistration.ts
+++ b/src/util/constraints/clientRegistration.ts
@@ -14,14 +14,4 @@ export default {
 			allowEmpty: false,
 		},
 	},
-	firstName: {
-		presence: {
-			allowEmpty: false,
-		},
-	},
-	lastName: {
-		presence: {
-			allowEmpty: false,
-		},
-	},
 };

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -2,10 +2,12 @@ import Constants from 'expo-constants';
 
 const DONOR = {
 	LOGIN_URL: '/donor_auth',
+	CREATE_URL: '/donors/create',
 };
 
 const CLIENT = {
 	LOGIN_URL: '/client_auth',
+	CREATE_URL: '/clients/create',
 };
 
 const getEnv = () => {


### PR DESCRIPTION

---

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](https://trello.com/c/qSRpVdCt/210-update-front-end-to-notify-user-when-they-try-to-register-an-email-already-in-use)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This is the client piece for the rails changes made [here](https://github.com/FoodIsLifeBGP/banana-rails/commit/5f5deeae22de129510fa8c58dfff4d71b948c869) and [here](https://github.com/FoodIsLifeBGP/banana-rails/commit/2e97ef99bc461f550081351f1ec70690ee9c39e7).  I'll squash my commits when I merge next time :grimacing: These changes handle the 409 response from the back end and let the user know that they're already registered under that email.  Additionally, I made some changes so that I could verify things end to end for the client since the code to register a new client or donor was not pointing at the proper end point.  



#### What is the current behavior? (You can also link to an open issue here)
Generic error when trying to use an email address that's already in the database.



#### What is the new behavior? (if this is a feature change)
Advise the user that their email is already in the system and that they should try resetting their password.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.



#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)




