### PR TITLE
TR_185 [Hotfix] Corrected Contact Us Route

### DIFF
--- a/src/routes/Route.tsx
+++ b/src/routes/Route.tsx
@@ -103,8 +103,14 @@ const donorOrClientDrawer = () => {
 	};
 
 	const COMMON_MENU = {
-		HelpScreen: {
-			screen: MainStack,
+		// HelpScreen: {
+		// screen: MainStack,
+		// navigationOptions: {
+		// drawerLabel: <MainOption text="Contact Us" icon="help" />,
+		// },
+		// },
+		ContactScreen: {
+			screen: ContactScreen,
 			navigationOptions: {
 				drawerLabel: <MainOption text="Contact Us" icon="help" />,
 			},


### PR DESCRIPTION
Realized after approving [PR #103](https://github.com/FoodIsLifeBGP/banana-rn/pull/103) that the `ContactUs` route that I had incorporated in [PR #93](https://github.com/FoodIsLifeBGP/banana-rn/pull/93) got overwritten

`ContactUs` menu link now works, please feel free to ask questions or share your comments regarding this hotfix