### PR TITLE
Fix: attempting to fetch user location causes donations screen not to load in web browser

### DIFF
--- a/src/library/Donations/Donations.tsx
+++ b/src/library/Donations/Donations.tsx
@@ -18,8 +18,7 @@ export default ({ resource }: LocalProps) => {
 	const [ loaded, setLoaded ] = useState(false);
 
 	const getDonationsOrClaimsFromApi = async () => {
-		const { getDonations, getActiveDonationsForClient, getLocation } = actions;
-		const coords = await getLocation();
+		const { getDonations, getActiveDonationsForClient } = actions;
 		const { userIdentity } = state;
 		const method = userIdentity === 'client' && resource === 'donations' ? getActiveDonationsForClient : getDonations;
 		const data = await method(resource);


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

I find testing the app in my web browser is fastest especially when just verifying proper communication with the back end, but this has tripped me up a couple of times.  In chromium on linux at least the getlocation call throws an uncaught exception which prevents the donations page from loading.  We don't currently use the results of the getlocation call so in the near term removing this seems like the fastest approach.

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix for testing in a browser.


#### What is the current behavior? (You can also link to an open issue here)
Donations screen fails to load in my browser.


#### What is the new behavior? (if this is a feature change)
Donations screen loads in my browser


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.


#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)




