### PR TITLE
[TR_232]Confirm Password Validation

### DIFF
--- a/src/util/constraints/clientRegistration.ts
+++ b/src/util/constraints/clientRegistration.ts
@@ -16,9 +16,6 @@ export default {
 		},
 	},
 	retypedPassword: {
-		presence: {
-			allowEmpty: false,
-		},
 		equality: 'password',
 	},
 	firstName: {

--- a/src/util/constraints/clientRegistration.ts
+++ b/src/util/constraints/clientRegistration.ts
@@ -15,6 +15,12 @@ export default {
 			allowEmpty: false,
 		},
 	},
+	retypedPassword: {
+		presence: {
+			allowEmpty: false,
+		},
+		equality: 'password',
+	},
 	firstName: {
 		presence: {
 			allowEmpty: false,

--- a/src/util/constraints/donorRegistration.ts
+++ b/src/util/constraints/donorRegistration.ts
@@ -16,9 +16,6 @@ export default {
 		},
 	},
 	retypedPassword: {
-		presence: {
-			allowEmpty: false,
-		},
 		equality: 'password',
 	},
 	firstName: {

--- a/src/util/constraints/donorRegistration.ts
+++ b/src/util/constraints/donorRegistration.ts
@@ -15,6 +15,12 @@ export default {
 			allowEmpty: false,
 		},
 	},
+	retypedPassword: {
+		presence: {
+			allowEmpty: false,
+		},
+		equality: 'password',
+	},
 	firstName: {
 		presence: {
 			allowEmpty: false,


### PR DESCRIPTION
[//]: # (Title Template: "[TR_##] Title")

---

#### Please check if the PR fulfills these requirements

- [X] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](https://trello.com/c/7LZMGXvq/232-use-validatejs-on-client-and-donor-registration-screens-to-make-sure-password-and-confirmpassword-match)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
The Confirm Password field on both the Donor and Client register screens must match the Password field above directly

#### What is the current behavior? (You can also link to an open issue here)
A registering user can leave the confirm password field blank when registering. The confirm password field does not have to match the password field.

#### What is the new behavior? (if this is a feature change)
Confirm password field must match the password to register. If they do not match, then an error message is displayed "Retyped password does not match password"


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
N/A


#### Other information
N/A


#### Discussion Questions
The default error message is "Retyped password is not equal to password", does that message work or should we include a custom message?


#### Images (before/ after screenshots, interaction GIFs, ...)
[Link](https://i.imgur.com/OJNMOK3.gifv)

---


#### TODO
N/A
