### PR TITLE
fix storybook warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3758,6 +3758,14 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "@react-native-community/async-storage": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.11.0.tgz",
+      "integrity": "sha512-Pq9LlmvtCEKAGdkyrgTcRxNh2fnHFykEj2qnRYijOl1pDIl2MkD5IxaXu5eOL0wgOtAl4U//ff4z40Td6XR5rw==",
+      "requires": {
+        "deep-assign": "^3.0.0"
+      }
+    },
     "@react-native-community/cli-debugger-ui": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
+    "@react-native-community/async-storage": "^1.11.0",
     "@react-native-community/eslint-config": "0.0.5",
     "@types/use-global-hook": "^0.1.2",
     "axios": "^0.19.0",

--- a/src/storybook/index.js
+++ b/src/storybook/index.js
@@ -11,7 +11,7 @@ configure(() => {
 
 // Refer to https://github.com/storybookjs/storybook/tree/master/app/react-native#start-command-parameters
 // To find allowed options for getStorybookUI
-const StorybookUIRoot = getStorybookUI();
+const StorybookUIRoot = getStorybookUI({ asyncStorage: require('@react-native-community/async-storage') });
 
 // If you are using React Native vanilla and after installation you don't see your app name here, write it manually.
 // If you use Expo you can safely remove this line.


### PR DESCRIPTION
Small fix to quiet Storybook warning introduced with this Storybook code change: https://github.com/storybookjs/storybook/pull/7801/files.  I've found the yellow warning distracting when testing in the expo app.