### PR TITLE
donor registration: move input focus to next text input on form after current input is finished

### DIFF
--- a/src/screens/RegistrationScreen/DonorRegistrationScreen.tsx
+++ b/src/screens/RegistrationScreen/DonorRegistrationScreen.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-tabs */
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useNavigation } from 'react-navigation-hooks';
 import {
 	KeyboardAvoidingView,
 	ScrollView,
 	Text, TouchableOpacity,
 	View,
-	Platform,
+	Platform, TextInput,
 } from 'react-native';
 import { Divider } from 'react-native-paper';
 import {
@@ -30,6 +30,15 @@ export default () => {
 	const [ validationErrors, setValidationErrors ] = useState({} as any);
 	const [ termsOfService, setTermsOfService ] = useState(false);
 	const stateList = getStateList();
+	const passwordRef = useRef<TextInput>(null);
+	const confirmPasswordRef = useRef<TextInput>(null);
+	const firstNameRef = useRef<TextInput>(null);
+	const lastNameRef = useRef<TextInput>(null);
+	const bizNameRef = useRef<TextInput>(null);
+	const bizAddressRef = useRef<TextInput>(null);
+	const cityRef = useRef<TextInput>(null);
+	const zipRef = useRef<TextInput>(null);
+	const pickUpRef = useRef<TextInput>(null);
 
 	const toggleTermsOfService = () => setTermsOfService(!termsOfService);
 	const validateInputs = async () => {
@@ -71,6 +80,8 @@ export default () => {
 					placeholder="info@bananaapp.org"
 					error={!!validationErrors.email}
 					errorMessage={validationErrors.email}
+					autoFocus={true}
+					onSubmitEditing={() => passwordRef?.current?.focus()}
 				/>
 
 				<FormTextInput
@@ -81,6 +92,8 @@ export default () => {
 					style={styles.input}
 					error={!!validationErrors.password}
 					errorMessage={validationErrors.password && validationErrors.password.join(', ')}
+					ref={passwordRef}
+					onSubmitEditing={() => confirmPasswordRef?.current?.focus()}
 				/>
 
 
@@ -92,6 +105,8 @@ export default () => {
 					type="password"
 					error={!!validationErrors.retypedPassword} // not doing anything right now
 					errorMessage={validationErrors.retypedPassword}
+					ref={confirmPasswordRef}
+					onSubmitEditing={() => firstNameRef?.current?.focus()}
 				/>
 				<Divider
 					style={{ marginVertical: 20 }}
@@ -104,6 +119,8 @@ export default () => {
 					style={styles.input}
 					error={!!validationErrors.firstName}
 					errorMessage={validationErrors.firstName}
+					ref={firstNameRef}
+					onSubmitEditing={() => lastNameRef?.current?.focus()}
 				/>
 
 
@@ -114,7 +131,8 @@ export default () => {
 					style={styles.input}
 					error={!!validationErrors.lastName}
 					errorMessage={validationErrors.lastName}
-
+					ref={lastNameRef}
+					onSubmitEditing={() => bizNameRef?.current?.focus()}
 				/>
 
 				<FormTextInput
@@ -124,6 +142,8 @@ export default () => {
 					style={styles.input}
 					error={!!validationErrors.businessName}
 					errorMessage={validationErrors.businessName}
+					ref={bizNameRef}
+					onSubmitEditing={() => bizAddressRef?.current?.focus()}
 				/>
 
 				<FormTextInput
@@ -133,7 +153,8 @@ export default () => {
 					style={styles.input}
 					error={!!validationErrors.businessAddress}
 					errorMessage={validationErrors.businessAddress}
-
+					ref={bizAddressRef}
+					onSubmitEditing={() => cityRef?.current?.focus()}
 				/>
 
 				<View style={[ styles.row, styles.input ]}>
@@ -145,6 +166,8 @@ export default () => {
 						autoCapitalize="words"
 						error={!!validationErrors.city}
 						errorMessage={validationErrors.city}
+						ref={cityRef}
+						onSubmitEditing={() => zipRef?.current?.focus()}
 					/>
 					<FormTextInput
 						label="State"
@@ -164,6 +187,8 @@ export default () => {
 						autoCapitalize="words"
 						error={!!validationErrors.zip}
 						errorMessage={validationErrors.zip}
+						ref={zipRef}
+						onSubmitEditing={() => pickUpRef?.current?.focus()}
 					/>
 				</View>
 				<FormTextInput
@@ -173,6 +198,7 @@ export default () => {
 					placeholder="Directions on where to pick up item"
 					error={!!validationErrors.pickupInstructions}
 					errorMessage={validationErrors.pickupInstructions}
+					ref={pickUpRef}
 				/>
 
 				<View style={styles.checkboxRow}>


### PR DESCRIPTION
[//]: # (Title Template: "[TR_##] Title")

---

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

In my testing, these changes make it easier to fill out the donor registration on my android device--I no longer have to tap into the next input in order to bring back the keyboard.  But I'd be interested to hear from other testers.