### PR TITLE
TR_251 Change Pickup Address Field

### DIFF
--- a/src/screens/DashboardScreen/DonationScreen/DonationScreen.styles.ts
+++ b/src/screens/DashboardScreen/DonationScreen/DonationScreen.styles.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+import typography from '@util/typography';
 
 const iconSize = 90;
 
@@ -28,5 +29,16 @@ export default StyleSheet.create({
 	},
 	button: {
 		marginBottom: 30,
+	},
+	pickupAddressLabel: {
+		...typography.h3,
+		marginBottom: 14,
+	},
+	pickupAddressStyle: {
+		...typography.body1,
+		marginBottom: 14,
+		paddingHorizontal: 10,
+		paddingVertical: 13,
+		left: 10,
 	},
 });

--- a/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
+++ b/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigation } from 'react-navigation-hooks';
 import {
 	View,
-	KeyboardAvoidingView, ScrollView, Platform,
+	KeyboardAvoidingView, ScrollView, Platform, Text,
 } from 'react-native';
 import useGlobal from '@state';
 import {
@@ -95,13 +95,14 @@ export default () => {
 					errorMessage={validateError.totalAmount}
 				/>
 
-				<FormTextInput
-					label="Pickup Address"
-					value={newDonation.pickupAddress}
-					setValue={s => setNewDonation({ ...newDonation, pickupAddress: s })}
-					style={styles.input}
-					editable={false}
-				/>
+				<View>
+					<Text style={styles.pickupAddressLabel}>
+						PICKUP ADDRESS
+					</Text>
+					<Text style={styles.pickupAddressStyle}>
+						{newDonation.pickupAddress}
+					</Text>
+				</View>
 
 				<FormTextInput
 					label="Pickup Instructions"


### PR DESCRIPTION
[//]: # (Title Template: "TR_251 Change Pickup Address Field")

---

#### Please check if the PR fulfills these requirements

- [X] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Figma](https://www.figma.com/file/Kzv8b6CHHq5Y5aCuBWAGLU/THE-BANANA-APP-BGP?node-id=5374%3A36)

### [Trello Card](https://trello.com/c/wdw9r2Zk/251-change-pickup-address-field-to-on-create-donation-screen-to-be-a-blue-text-element-rather-than-a-read-only-form-input-as-per-fig)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- 'Pickup Address' field is edited on create donation screen.

#### What is the current behavior? (You can also link to an open issue here)

- A read only FormTextInput is currently used in DonationScreen.tsx to render the address from the donors table. 

#### What is the new behavior? (if this is a feature change)

- FormInputText is removed and Text with proper styling (blue text element) is added to match figma.

#### Images (before/ after screenshots, interaction GIFs, ...)

<img width="350" alt="#251_ChangePickupAddressField" src="https://user-images.githubusercontent.com/53732116/88238552-ceea8e00-cc36-11ea-8b23-48bd6bd3dd59.png">

---

