### PR TITLE
[TR_252] Change Donation Category Image

### DIFF
--- a/src/screens/DashboardScreen/DonationScreen/DonationScreen.styles.ts
+++ b/src/screens/DashboardScreen/DonationScreen/DonationScreen.styles.ts
@@ -1,7 +1,6 @@
 import { StyleSheet } from 'react-native';
 import typography from '@util/typography';
-
-const iconSize = 90;
+import * as colors from '@util/colors';
 
 export default StyleSheet.create({
 	keyboardAvoidContainer: {
@@ -18,6 +17,13 @@ export default StyleSheet.create({
 		width: '100%',
 		justifyContent: 'center',
 		alignItems: 'center',
+	},
+	icon: {
+		height: 60,
+		width: 60,
+		borderRadius: 30,
+		borderColor: colors.NAVY_BLUE,
+		borderWidth: 2,
 	},
 	input: {
 		marginBottom: 14,

--- a/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
+++ b/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigation } from 'react-navigation-hooks';
 import {
 	View,
-	KeyboardAvoidingView, ScrollView, Platform, Text,
+	KeyboardAvoidingView, ScrollView, Platform, Text, Image,
 } from 'react-native';
 import useGlobal from '@state';
 import {
@@ -10,12 +10,11 @@ import {
 	SpacerInline,
 	FormTextInput,
 	LinkButton,
-	InputLabel, Title, FormImageInput,
 } from '@elements';
 import validate from 'validate.js';
 import { NewDonation } from '@screens/DashboardScreen/DonationScreen/DonationScreen.type';
 import donationConstraints from '@util/constraints/donation';
-import { ImageInfo } from 'expo-image-picker/build/ImagePicker.types';
+import { categoryImage } from '@util/donationCategory';
 import styles from './DonationScreen.styles';
 
 export default () => {
@@ -23,7 +22,6 @@ export default () => {
 	const { user } = state;
 	const [ newDonation, setNewDonation ] = useState<NewDonation>({ pickupInstructions: user.pickup_instructions } as NewDonation);
 	const [ validateError, setValidateError ] = useState({} as any);
-	const [ image, setImage ] = useState({} as ImageInfo);
 	const { postDonation } = actions;
 	const { navigate } = useNavigation();
 
@@ -54,14 +52,9 @@ export default () => {
 		>
 			<NavBar showBackButton={true} />
 			<ScrollView style={styles.scrollContainer}>
+
 				<View style={styles.imageInputContainer}>
-					<FormImageInput
-						label=""
-						value={image}
-						setValue={setImage}
-						status={image?.uri ? 'success' : undefined}
-						shape="circular"
-					/>
+					<Image source={categoryImage(newDonation.category)} style={styles.icon} />
 				</View>
 
 				<SpacerInline height={20} />


### PR DESCRIPTION
[//]: # (Title Template: "[TR_#252] Change Donation Category Image")

---

#### Please check if the PR fulfills these requirements

- [X] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---
### [Figma](https://www.figma.com/file/Kzv8b6CHHq5Y5aCuBWAGLU/THE-BANANA-APP-BGP?node-id=5789%3A456)

### [Trello Card](https://trello.com/c/F1I9g0dF/252-change-the-donation-category-circular-image-once-donor-selects-a-category-on-the-donation-screen)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Circular image on the create donation screen changes when a category is selected.

#### What is the current behavior? (You can also link to an open issue here)

- There is a FormImageInput placeholder at the top of the DonationScreen.tsx. 

#### What is the new behavior? (if this is a feature change)

- FormImageInput is removed and an Image is added in a way that the source of the image changes depending on the category selected.


#### Images (before/ after screenshots, interaction GIFs, ...)

<img width="349" alt="#252" src="https://user-images.githubusercontent.com/53732116/88630096-fdb49a00-d064-11ea-81d2-1e37c3944471.png">

---

![#252](https://user-images.githubusercontent.com/53732116/88630156-0b6a1f80-d065-11ea-912d-899fc751d8a0.gif)

#### TODO

