### PR TITLE
TR_253 Incomplete Form Modal Setup

### DIFF
--- a/src/elements/IncompleteFormAlert/IncompleteFormAlert.tsx
+++ b/src/elements/IncompleteFormAlert/IncompleteFormAlert.tsx
@@ -30,11 +30,13 @@ export default ({
 	const handleNo = () => {
 		clearAlert();
 		onNo();
+		alertObj.cancelFn && alertObj.cancelFn();
 	};
 
 	const handleYes = () => {
 		clearAlert();
 		onYes();
+		alertObj.confirmFn && alertObj.confirmFn();
 	};
 
 	const handleCloseButtonPress = () => {

--- a/src/elements/NavBar/NavBar.tsx
+++ b/src/elements/NavBar/NavBar.tsx
@@ -19,6 +19,7 @@ interface NavBarProps {
 	position?: 'map'|'list';
 	onMap?: () => any;
 	onList?: () => any;
+	backButtonFn?: () => void;
 }
 
 export default ({
@@ -30,6 +31,7 @@ export default ({
 	position,
 	onMap,
 	onList,
+	backButtonFn,
 
 }: NavBarProps) => {
 	const { navigate, goBack } = useNavigation();
@@ -48,7 +50,7 @@ export default ({
 					leftButton === 'back' && showBackButton && (
 						<Button
 							buttonStyle={buttonStyle}
-							onPress={backDestination ? () => navigate(backDestination) : () => goBack()}
+							onPress={backButtonFn || (backDestination ? () => navigate(backDestination) : () => goBack())}
 						>
 							{foregroundColor => (<Icon size={36} color={foregroundColor} name="back" />)}
 						</Button>

--- a/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
+++ b/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
@@ -26,9 +26,13 @@ export default () => {
 	const { postDonation } = actions;
 	const { navigate, goBack } = useNavigation();
 
+	const hasUnsavedChanges = Boolean(newDonation.itemName || newDonation.totalAmount);
+
 	const foodCategories: Array<string> = [ 'Bread', 'Dairy', 'Hot Meal', 'Produce', 'Protein', 'Others' ];
 	newDonation.pickupAddress = `${user.address_street} ${user.address_city}, ${user.address_state} ${user.address_zip}`;
-
+	const preventBack = () => {
+		updateAlert({ type: 'incomplete form', dismissable: false, confirmFn: () => goBack() });
+	}
 	const validateInputs = async () => {
 		const validateResults = validate(newDonation, donationConstraints);
 		if (validateResults) {
@@ -53,9 +57,7 @@ export default () => {
 		>
 			<NavBar
 				showBackButton={true}
-				backButtonFn={() => {
-					updateAlert({ type: 'incomplete form', dismissable: false, confirmFn: () => goBack() });
-				}}
+				backButtonFn={hasUnsavedChanges ? preventBack : undefined}
 			/>
 			<ScrollView style={styles.scrollContainer}>
 

--- a/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
+++ b/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
@@ -32,7 +32,7 @@ export default () => {
 	newDonation.pickupAddress = `${user.address_street} ${user.address_city}, ${user.address_state} ${user.address_zip}`;
 	const preventBack = () => {
 		updateAlert({ type: 'incomplete form', dismissable: false, confirmFn: () => goBack() });
-	}
+	};
 	const validateInputs = async () => {
 		const validateResults = validate(newDonation, donationConstraints);
 		if (validateResults) {

--- a/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
+++ b/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
@@ -26,7 +26,7 @@ export default () => {
 	const { postDonation } = actions;
 	const { navigate, goBack } = useNavigation();
 
-	const hasUnsavedChanges = Boolean(newDonation.itemName || newDonation.totalAmount);
+	const hasUnsavedChanges = Boolean(newDonation.itemName || newDonation.totalAmount || newDonation.pickupInstructions !== user.pickup_instructions);
 
 	const foodCategories: Array<string> = [ 'Bread', 'Dairy', 'Hot Meal', 'Produce', 'Protein', 'Others' ];
 	newDonation.pickupAddress = `${user.address_street} ${user.address_city}, ${user.address_state} ${user.address_zip}`;

--- a/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
+++ b/src/screens/DashboardScreen/DonationScreen/DonationScreen.tsx
@@ -19,11 +19,12 @@ import styles from './DonationScreen.styles';
 
 export default () => {
 	const [ state, actions ] = useGlobal() as any;
+	const { updateAlert } = actions;
 	const { user } = state;
 	const [ newDonation, setNewDonation ] = useState<NewDonation>({ pickupInstructions: user.pickup_instructions } as NewDonation);
 	const [ validateError, setValidateError ] = useState({} as any);
 	const { postDonation } = actions;
-	const { navigate } = useNavigation();
+	const { navigate, goBack } = useNavigation();
 
 	const foodCategories: Array<string> = [ 'Bread', 'Dairy', 'Hot Meal', 'Produce', 'Protein', 'Others' ];
 	newDonation.pickupAddress = `${user.address_street} ${user.address_city}, ${user.address_state} ${user.address_zip}`;
@@ -50,7 +51,12 @@ export default () => {
 			enabled={true}
 			keyboardVerticalOffset={Platform.OS === 'ios' ? 64 : 0}
 		>
-			<NavBar showBackButton={true} />
+			<NavBar
+				showBackButton={true}
+				backButtonFn={() => {
+					updateAlert({ type: 'incomplete form', dismissable: false, confirmFn: () => goBack() });
+				}}
+			/>
 			<ScrollView style={styles.scrollContainer}>
 
 				<View style={styles.imageInputContainer}>

--- a/src/state/index.types.ts
+++ b/src/state/index.types.ts
@@ -72,6 +72,10 @@ export interface Alert {
 	 * (i.e. tapping the content behind a modal).
 	 */
 	dismissable?: boolean;
+
+	cancelFn?: () => void;
+
+	confirmFn?: () => void;
 }
 
 export interface InitialState {


### PR DESCRIPTION
[//]: # (Title Template: "[TR_253] Title")

---

#### Please check if the PR fulfills these requirements

- [X] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](https://trello.com/c/Xu3esVVD/253-show-are-you-sure-modal-when-user-navigates-away-from-create-donation-screen-without-publishing)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
When a donor leaves the page without publishing, an 'Are you sure' modal appears that allows them to click yes and navigate back or click no and dismiss the modal. If any of the text input fields (item name, amount, and pickup instructions) are not equal to their default when attempting to navigate back, the modal will appear. If these fields are equal to their default, it reverts to default behavior. Thank you to Drew for helping with setting up some of the plumbing behind navBar navigation!

#### What is the current behavior? (You can also link to an open issue here)
User can freely return to the home screen despite a field with input values filled in.

#### What is the new behavior? (if this is a feature change)
See below

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
It shouldn't. It does add props to the navBar but it is self-contained.

#### Other information



#### Discussion Questions
N/A


#### Images (before/ after screenshots, interaction GIFs, ...)
![Demo](https://media.giphy.com/media/Uv1k7z1uyMEwJaefWh/giphy.gif)

---


#### TODO
N/A
