### PR TITLE
[TR_42] Modal on QR Code Scan

### DIFF
--- a/src/screens/QRCodeScannerScreen/QRCodeScannerScreen.tsx
+++ b/src/screens/QRCodeScannerScreen/QRCodeScannerScreen.tsx
@@ -37,14 +37,6 @@ export default () => {
 	const getDate = () => new Date().toDateString().slice(4).split(' ')
 		.join('/');
 
-	/* Random data */
-	const data = {
-		date: getDate(),
-		time: getTime(),
-		by: 'Ernest Bruno',
-		name: 'Banana',
-	};
-
 	const getPermissions = async () => {
 		const { status } = await Permissions.askAsync(Permissions.CAMERA);
 		setHasCameraPermission(status === 'granted');
@@ -53,6 +45,13 @@ export default () => {
 	const handleBarCodeScanned = barcode => {
 		setScanned(barcode);
 		setModalOn(true);
+	};
+
+	const data = {
+		date: getDate(),
+		time: getTime(),
+		by: 'Ernest Bruno',
+		name: 'LUL',
 	};
 
 	// Triggers when user clicks outside of modal.
@@ -65,8 +64,9 @@ export default () => {
 
 	// Switch for Modal Content.
 	const ModalContent = () => {
-		switch (scanned.data) {
-			case ('Banana'): return (
+		let content;
+		if (scanned.data) {
+			content = (
 				<>
 					<Modal title="ITEM DONATED" open={modalOn} onDismiss={handleDismiss} palette="secondary">
 						<View style={styles.content}>
@@ -100,7 +100,8 @@ export default () => {
 					</Modal>
 				</>
 			);
-			case ('Error'): return (
+		} else {
+			content = (
 				<>
 					<Modal title="SOMETHING WENT WRONG" open={modalOn} onDismiss={handleDismiss} palette="secondary">
 						<View style={styles.content}>
@@ -122,8 +123,8 @@ export default () => {
 					</Modal>
 				</>
 			);
-			default: return (<></>);
 		}
+		return content;
 	};
 
 	const ScannerContent = () => {


### PR DESCRIPTION
[//]: # (Title Template: "[TR_42] Title")

---

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](trello.com/https://trello.com/c/qpcihsVs/42-d-update-qr-screen-confirmation-popup)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR fixes a mismatch on the data being checked when the Scanner scans a QR code, which prevented the modal to appear.


#### What is the current behavior? (You can also link to an open issue here)
No modal appearing when QR code is scanned.


#### What is the new behavior? (if this is a feature change)
A Modal now appears when the Scanner scans a QR code presented by a client.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
None.


#### Other information
None.


#### Discussion Questions
None

#### Images (before/ after screenshots, interaction GIFs, ...)


---
![ezgif com-optimize](https://user-images.githubusercontent.com/34993883/89110280-17a40300-d3fe-11ea-8e04-1105841b4adb.gif)


#### TODO
So this PR is not complete -- it is missing some important functionalities like retrieving the claim based on the data returned by the QR code, and displaying the necessary data to the modal that appears on scan success.

In order to do that, I will need to figure out which endpoint to use in order to get the data. What I'm thinking is creating a `railsAxios.get` call somewhere inside the `handleBarCodeScanned` function in the QRCodeScannerScreen component.
