### PR TITLE
[TR_42] Update QR Screen + confirmation popup

### DIFF
--- a/src/screens/QRCodeScannerScreen/QRCodeScannerScreen.styles.ts
+++ b/src/screens/QRCodeScannerScreen/QRCodeScannerScreen.styles.ts
@@ -1,6 +1,9 @@
 import { StyleSheet } from 'react-native';
 import * as colors from '@util/colors';
 
+const iconSize = 70;
+const imageSize = iconSize * 0.90;
+
 export default StyleSheet.create({
 	container: {
 		flex: 1,
@@ -18,10 +21,7 @@ export default StyleSheet.create({
 	},
 	textContainer: {
 		flex: 1,
-		marginVertical: 3,
 		color: colors.NAVY_BLUE,
-		justifyContent: 'center',
-		alignItems: 'center',
 		flexDirection: 'row',
 	},
 	textStyle: {
@@ -40,14 +40,21 @@ export default StyleSheet.create({
 	},
 	buttonTextStyle: {
 		fontSize: 12,
-		paddingHorizontal: 15,
+		paddingHorizontal: 25,
 	},
-	circle: {
-		height: 75,
-		width: 75,
+	icon: {
+		height: imageSize,
+		width: imageSize,
+		borderRadius: (imageSize / 2),
+		borderColor: colors.NAVY_BLUE,
 		borderWidth: 2,
-		borderColor: 'blue',
-		borderRadius: 50,
-		marginBottom: 10,
+		marginBottom: 15,
+	},
+	claimTitle: {
+		color: colors.NAVY_BLUE,
+		marginLeft: 3,
+		fontWeight: 'bold',
+		marginBottom: 15,
+		fontSize: 20,
 	},
 });

--- a/src/state/actions/scan.ts
+++ b/src/state/actions/scan.ts
@@ -1,7 +1,8 @@
 import railsAxios from '@util/railsAxios';
 
-export const scan = async ({ qrCode, jwt }) => {
+export const scan = async (_store, qrCode) => {
 	try {
+		const { jwt } = _store.state;
 		const response = await railsAxios(jwt).post('/donors/scan', {
 			qr_code: qrCode,
 		});


### PR DESCRIPTION
[//]: # (Title Template: "[TR_42] Update QR screen + confirmation popup")

---

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](trello.com/https://trello.com/c/qpcihsVs/42-d-update-qr-screen-confirmation-popup)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR fixes a mismatch on the data being checked when the Scanner scans a QR code, which prevented the modal to appear. Modal also dynamically displays data based on the QR code scanned.


#### What is the current behavior? (You can also link to an open issue here)
No modal appearing when QR code is scanned.


#### What is the new behavior? (if this is a feature change)
A Modal now appears when the Scanner scans a QR code presented by a client.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
None.


#### Other information
None.


#### Discussion Questions
I want to point out that the camera will continuously scan for a QR code that lands inside the camera range -- handleBarCodeScanned which contains an API call will keep getting called. 

I have been looking for a way to disable the camera or at least just the scanning function when the modal appears. A possible solution is to have a state slice called `scannerActive` which will return true or false and will be used to see if the scanner is active (notice lines 30, 61, and 148 on QRCodeScannerScreen.tsx to see how it's implemented [if we decide to do so]). However, the downside (if it is a downside) of this is that the backdrop turns white (I think due to the BarCodeMask component line 153)... not the prettiest, but prevents the camera from scanning unnecessarily.

Please feel free to share what you think about this concern!

#### Images (before/ after screenshots, interaction GIFs, ...)

---
![ezgif com-resize](https://user-images.githubusercontent.com/34993883/89475035-09c2ea80-d73c-11ea-8c02-5ed6e78f617e.gif)


#### TODO