### PR TITLE
Add bundleIdentifier for Apple App Store

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,7 +24,8 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+			"supportsTablet": true,
+			"bundleIdentifier": "com.thebegoodproject.org.bananaapp"
     },
     "extra": {
       "variant": "donor",


### PR DESCRIPTION
[//]: # (Title Template: "[TR_264] Investigate if there are ways to let iOS device users test the apps without having to install xcode.")

---

#### Please check if the PR fulfills these requirements

- [x ] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [TR-264](https://trello.com/c/nj2cYnGo)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Added bundleIdentifier to allow publishing to Apple TestFlight (and the Apple App Store in the future). This will allow for app testing using 


#### What is the current behavior? (You can also link to an open issue here)
There is not currently a bundleIdentifier


#### What is the new behavior? (if this is a feature change)
The app.json now contains a bundleIdentifier


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
N/A


#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)


---


#### TODO

