### PR TITLE
[TR_268]Change initial route name for nested navigator

### DIFF
--- a/src/routes/Route.tsx
+++ b/src/routes/Route.tsx
@@ -50,7 +50,7 @@ export const MainStack = createStackNavigator(
 	},
 	{
 		headerMode: 'none',
-		initialRouteName: 'DashboardScreen',
+		initialRouteName: 'LoginSuccessScreen',
 	},
 );
 


### PR DESCRIPTION
[//]: # (Title Template: "[TR_##] Title")

---

#### Please check if the PR fulfills these requirements

- [X ] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](https://trello.com/c/ExFxRFxY/268-sliding-on-application-pending-allows-access-to-donations)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Addressing the [issue](https://github.com/FoodIsLifeBGP/banana-rn/issues/115) where a pending user could access the dashboard. 

Since Dashboard Screen was the initial route inside the drawer navigation, the client dashboard was always being pushed to the navigator stack inside the drawer navigator, regardless of user account status (suspended, pending, approved, active) or variant (client or donor). This meant regardless of variant or account status, a user that has entered this navigator (which occurs when accessing the LoginSuccess Page after login) could press the back button enough times that they could navigate back to the client dashboard screen.

From the react navigation docs:
`Initial Route Name: The name of the route to render on first load of the navigator.`

The fix was fairly easy. The LoginSuccess page is that page that does the conditional rendering based on account status and variant. I set the LoginSuccess page as the initial route inside this navigator instead. This seems to solve the issue. I played around with different routes for the app and everything works well. I don't think it should break anything since the LoginSuccess screen was always the defacto intro screen to this navigator anyways (from login). 
#### What is the current behavior? (You can also link to an open issue here)
See below!


#### What is the new behavior? (if this is a feature change)
The Login Success page is now the default initial route for the MainStackNavigator. See below.  
See below!

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
As mentioned above, it shouldn't!


#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)
BEFORE:
As active donor:
![AD](https://media.giphy.com/media/YpkhGAvcSr50NRpTJt/giphy.gif)
As pending donor:
![AD](https://media.giphy.com/media/JpGw0gXNcs9fAS5JjB/giphy.gif)
AFTER:
As active donor:
![AD](https://media.giphy.com/media/ckrHInYRUITziBxmeb/giphy.gif)
As pending donor:
![AD](https://media.giphy.com/media/j2pJubfdtfyLT8kToG/giphy.gif)

---


#### TODO

