### PR TITLE
Navbar Styling

### DIFF
--- a/src/elements/HamburgerPopupMenu/HamburgerPopupMenu.tsx
+++ b/src/elements/HamburgerPopupMenu/HamburgerPopupMenu.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigation } from 'react-navigation-hooks';
 import { TouchableOpacity } from 'react-native';
 import { Icon } from '@elements';
+import { NAVBAR_ICON_SIZE } from '@util/constants';
 
 
 export default () => {
@@ -9,7 +10,7 @@ export default () => {
 
 	return (
 		<TouchableOpacity onPress={toggleDrawer}>
-			<Icon name="menu" size={32} />
+			<Icon name="menu" size={NAVBAR_ICON_SIZE} />
 		</TouchableOpacity>
 	);
 };

--- a/src/elements/HamburgerPopupMenu/HamburgerPopupMenu.tsx
+++ b/src/elements/HamburgerPopupMenu/HamburgerPopupMenu.tsx
@@ -9,7 +9,7 @@ export default () => {
 
 	return (
 		<TouchableOpacity onPress={toggleDrawer}>
-			<Icon name="menu" size={36} />
+			<Icon name="menu" size={32} />
 		</TouchableOpacity>
 	);
 };

--- a/src/elements/NavBar/NavBar.styles.ts
+++ b/src/elements/NavBar/NavBar.styles.ts
@@ -1,4 +1,5 @@
 import { Platform, StyleSheet, Dimensions } from 'react-native';
+import Constants from 'expo-constants';
 import * as colors from '@util/colors';
 
 const screenWidth = Math.round(Dimensions.get('window').width);
@@ -12,11 +13,12 @@ export default StyleSheet.create({
 	},
 	contentContainer: {
 		backgroundColor: colors.LIGHT_GRAY,
-		height: 60,
+		height: 56 + Constants.statusBarHeight,
 		width: screenWidth,
 		flexDirection: 'row',
 		justifyContent: 'space-between',
 		alignItems: 'center',
+		paddingTop: Constants.statusBarHeight,
 		borderBottomWidth: 2,
 		borderColor: colors.NAVY_BLUE,
 
@@ -38,6 +40,7 @@ export default StyleSheet.create({
 		justifyContent: 'center',
 		alignItems: 'center',
 		flexBasis: 100,
+		marginRight: 15,
 	},
 	selectorContainer: {
 		flexDirection: 'row',

--- a/src/elements/NavBar/NavBar.tsx
+++ b/src/elements/NavBar/NavBar.tsx
@@ -6,6 +6,7 @@ import { ButtonStyle } from '@elements/Button';
 import * as colors from '@util/colors';
 import Selector from '@elements/NavBar/Selector';
 import useGlobal from '@state';
+import { NAVBAR_ICON_SIZE } from '@util/constants';
 import HamburgerPopupMenu from '../HamburgerPopupMenu';
 import styles from './NavBar.styles';
 
@@ -51,7 +52,7 @@ export default ({
 							buttonStyle={buttonStyle}
 							onPress={backButtonFn || (backDestination ? () => navigate(backDestination) : () => goBack())}
 						>
-							{foregroundColor => (<Icon size={32} color={foregroundColor} name="back" />)}
+							{foregroundColor => (<Icon size={NAVBAR_ICON_SIZE} color={foregroundColor} name="back" />)}
 						</Button>
 					)
 				}
@@ -61,7 +62,7 @@ export default ({
 							buttonStyle={buttonStyle}
 							onPress={() => navigate('QRCodeScannerScreen')}
 						>
-							{foregroundColor => (<Icon size={32} color={foregroundColor} name="qrCode" />)}
+							{foregroundColor => (<Icon size={NAVBAR_ICON_SIZE} color={foregroundColor} name="qrCode" />)}
 						</Button>
 					)
 				}
@@ -75,7 +76,7 @@ export default ({
 					style={{ marginTop: 4, marginRight: 8 }}
 					onPress={() => { updateAlert({ type: 'coming soon', dismissable: false }); }}
 				>
-					{foregroundColor => (<Icon size={32} color={foregroundColor} name="bell" />)}
+					{foregroundColor => (<Icon size={NAVBAR_ICON_SIZE} color={foregroundColor} name="bell" />)}
 				</Button>
 				{showMenu && (<HamburgerPopupMenu />) }
 			</View>

--- a/src/elements/NavBar/NavBar.tsx
+++ b/src/elements/NavBar/NavBar.tsx
@@ -51,7 +51,7 @@ export default ({
 							buttonStyle={buttonStyle}
 							onPress={backButtonFn || (backDestination ? () => navigate(backDestination) : () => goBack())}
 						>
-							{foregroundColor => (<Icon size={36} color={foregroundColor} name="back" />)}
+							{foregroundColor => (<Icon size={32} color={foregroundColor} name="back" />)}
 						</Button>
 					)
 				}
@@ -61,7 +61,7 @@ export default ({
 							buttonStyle={buttonStyle}
 							onPress={() => navigate('QRCodeScannerScreen')}
 						>
-							{foregroundColor => (<Icon size={36} color={foregroundColor} name="qrCode" />)}
+							{foregroundColor => (<Icon size={32} color={foregroundColor} name="qrCode" />)}
 						</Button>
 					)
 				}
@@ -75,7 +75,7 @@ export default ({
 					style={{ marginTop: 4, marginRight: 8 }}
 					onPress={() => { updateAlert({ type: 'coming soon', dismissable: false }); }}
 				>
-					{foregroundColor => (<Icon size={36} color={foregroundColor} name="bell" />)}
+					{foregroundColor => (<Icon size={32} color={foregroundColor} name="bell" />)}
 				</Button>
 				{showMenu && (<HamburgerPopupMenu />) }
 			</View>

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,0 +1,1 @@
+export const NAVBAR_ICON_SIZE = 32;


### PR DESCRIPTION
[//]: # (Title Template: "[TR_##] Title")

---

#### Please check if the PR fulfills these requirements

- [X ] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

Bug listed on our bug spreadsheet (see slack channel)
"The icons(notification, menu) covers my phone's status bar (where you see left battery %)"

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Adds padding to the top of Navbar in Android corresponding to the size of the Android Status bar. 
Fix found here: https://github.com/react-navigation/react-navigation/issues/1478
Also, added space to the right of the hamburger icon and made the icons a little smaller, as requested in the spreadsheet. 


#### What is the current behavior? (You can also link to an open issue here)
See photo below


#### What is the new behavior? (if this is a feature change)
See photo below


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


#### Other information



#### Discussion Questions
Should icon size (an nav height) be hardcoded or be a function of the screen size? As far as I could tell, nav height is fairly consistent for android devices (~60px). If nav height is consistent, then hardcoding icon size may make sense. 


#### Images (before/ after screenshots, interaction GIFs, ...)
Before:
![Before](https://i.imgur.com/l5kRSCl.png)
After:
![After](https://i.imgur.com/NoFFtfo.png)
---
#### TODO
