### PR TITLE
Changed close QR scan button to go to last page

### DIFF
--- a/src/screens/QRCodeScannerScreen/BarCodeMask.tsx
+++ b/src/screens/QRCodeScannerScreen/BarCodeMask.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@elements';
 import styles from './BarCodeMask.styles';
 
 export default () => {
-	const { navigate } = useNavigation();
+	const { goBack } = useNavigation();
 	return (
 		<>
 			<View style={styles.reticleUL} />
@@ -15,10 +15,10 @@ export default () => {
 			<View style={styles.reticleDR} />
 			<View style={styles.background} />
 			<View style={styles.xContainer}>
-				<TouchableWithoutFeedback onPress={() => navigate('DashboardScreen')}>
+				<TouchableWithoutFeedback onPress={() => goBack()}>
 					<Icon name="chevron-left" size={48} color="gray" />
 				</TouchableWithoutFeedback>
-				<TouchableWithoutFeedback onPress={() => navigate('DashboardScreen')}>
+				<TouchableWithoutFeedback onPress={() => goBack()}>
 					<Icon name="close" size={48} color="gray" />
 				</TouchableWithoutFeedback>
 			</View>


### PR DESCRIPTION
[//]: # (Title Template: "[TR_##] Title")

---

#### Please check if the PR fulfills these requirements

- [X ] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](trello.com/LINK-TO-TRELLO-CARD)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix noted in the bug spreadsheet (High Severity):
"I clicked scan QR code from donor's menu but once I hit the icons on top (x or back) it directs me to the client app donations-blank state screen"

Hitting the icons now brings the user back to the previous screen in the navigation stack instead of to the client dashboard
#### What is the current behavior? (You can also link to an open issue here)
When a donor navigates to the QR Code screen, pressing the chevron-left or close buttons on the screen brings the user to the client dashboard screen. I think this may be leftover from earlier in the project when perhaps not enough of the infrastructure had been set up yet.  

#### What is the new behavior? (if this is a feature change)
The buttons now bring the user back to the previous page in their history.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

#### Images (before/ after screenshots, interaction GIFs, ...)
![](https://media.giphy.com/media/duL5DVhBu0I9TaQj8b/giphy.gif)

