### PR TITLE
Disable auto-capitalization of email - iOS

### DIFF
--- a/src/screens/RegistrationScreen/ClientRegistrationScreen.tsx
+++ b/src/screens/RegistrationScreen/ClientRegistrationScreen.tsx
@@ -112,6 +112,7 @@ export default () => {
 					errorMessage={validateError.email}
 					autoFocus={true}
 					onSubmitEditing={() => passwordRef?.current?.focus()}
+					autoCapitalize="none"
 				/>
 
 				<FormTextInput

--- a/src/screens/RegistrationScreen/DonorRegistrationScreen.tsx
+++ b/src/screens/RegistrationScreen/DonorRegistrationScreen.tsx
@@ -108,6 +108,7 @@ export default () => {
 					errorMessage={validationErrors.email}
 					autoFocus={true}
 					onSubmitEditing={() => passwordRef?.current?.focus()}
+					autoCapitalize="none"
 				/>
 
 				<FormTextInput


### PR DESCRIPTION
[//]: # (Disable New User Email Auto-capitalization: "[TR_##]")

---

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Fix for GitHub issue 181](https://github.com/FoodIsLifeBGP/banana-rn/issues/181)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
* Disables auto-capitalization of email address on new Client / Donor forms


#### What is the current behavior? (You can also link to an open issue here)
* Currently, when a new user begins filling out the registration form, their email address is being auto-capitalized


#### What is the new behavior? (if this is a feature change)
* Auto capitalization is disabled


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
N/A


#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)


---


#### TODO

